### PR TITLE
Add 9 new orchestrator migration skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "MLOps and LLMOps workflow automation tools for ZenML users",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "homepage": "https://docs.zenml.io",
     "repository": "https://github.com/zenml-io/skills"
   },
@@ -103,6 +103,30 @@
       ]
     },
     {
+      "name": "zenml-argo-migration",
+      "source": "./skills/zenml-argo-migration",
+      "description": "Migrate Argo Workflows to idiomatic ZenML pipelines with concept mapping, code translation, Kubernetes-native pattern flagging, and redesign guidance",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "argo",
+        "argo-workflows",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration",
+        "kubernetes"
+      ]
+    },
+    {
       "name": "zenml-databricks-migration",
       "source": "./skills/zenml-databricks-migration",
       "description": "Migrate Databricks Workflows (Lakeflow Jobs) to idiomatic ZenML pipelines with concept mapping, notebook refactoring, code translation, and unsupported pattern flagging",
@@ -124,6 +148,196 @@
         "orchestration",
         "notebooks",
         "lakeflow"
+      ]
+    },
+    {
+      "name": "zenml-prefect-migration",
+      "source": "./skills/zenml-prefect-migration",
+      "description": "Migrate Prefect flows and workflows to idiomatic ZenML pipelines with concept mapping, dynamic-execution analysis, code translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "prefect",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration",
+        "flows"
+      ]
+    },
+    {
+      "name": "zenml-vertexai-migration",
+      "source": "./skills/zenml-vertexai-migration",
+      "description": "Migrate Vertex AI Pipelines (KFP v2 / PipelineJob workflows) to idiomatic ZenML pipelines with concept mapping, artifact-contract translation, GCPC rewrite guidance, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "vertexai",
+        "vertex-ai",
+        "kubeflow",
+        "kfp",
+        "gcpc",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration"
+      ]
+    },
+    {
+      "name": "zenml-azureml-migration",
+      "source": "./skills/zenml-azureml-migration",
+      "description": "Migrate Azure Machine Learning SDK v2 pipelines to idiomatic ZenML pipelines with concept mapping, Azure-aware compute translation, code patterns, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "azureml",
+        "azure-machine-learning",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration",
+        "mldesigner"
+      ]
+    },
+    {
+      "name": "zenml-kedro-migration",
+      "source": "./skills/zenml-kedro-migration",
+      "description": "Migrate Kedro pipelines and projects to idiomatic ZenML pipelines with concept mapping, Data Catalog to artifact translation, code translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "kedro",
+        "migration",
+        "mlops",
+        "pipelines",
+        "catalog",
+        "artifacts"
+      ]
+    },
+    {
+      "name": "zenml-flyte-migration",
+      "source": "./skills/zenml-flyte-migration",
+      "description": "Migrate Flyte workflows, tasks, and LaunchPlans to idiomatic ZenML pipelines with concept mapping, code translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "flyte",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration",
+        "workflows",
+        "launchplans"
+      ]
+    },
+    {
+      "name": "zenml-dagster-migration",
+      "source": "./skills/zenml-dagster-migration",
+      "description": "Migrate Dagster assets, ops, jobs, and asset-graph workflows to idiomatic ZenML pipelines with concept mapping, asset-boundary planning, code translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "dagster",
+        "migration",
+        "mlops",
+        "pipelines",
+        "assets",
+        "orchestration"
+      ]
+    },
+    {
+      "name": "zenml-metaflow-migration",
+      "source": "./skills/zenml-metaflow-migration",
+      "description": "Migrate Metaflow flows to idiomatic ZenML pipelines with FlowSpec mapping, artifact translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "metaflow",
+        "migration",
+        "mlops",
+        "pipelines",
+        "flows",
+        "flowspec",
+        "outerbounds"
+      ]
+    },
+    {
+      "name": "zenml-sagemaker-migration",
+      "source": "./skills/zenml-sagemaker-migration",
+      "description": "Migrate Amazon SageMaker Pipelines and workflow code to idiomatic ZenML pipelines with concept mapping, code translation, and unsupported pattern flagging",
+      "version": "1.0.0",
+      "author": {
+        "name": "ZenML Team",
+        "url": "https://github.com/zenml-io"
+      },
+      "homepage": "https://docs.zenml.io",
+      "repository": "https://github.com/zenml-io/skills",
+      "license": "Apache-2.0",
+      "category": "mlops",
+      "keywords": [
+        "zenml",
+        "sagemaker",
+        "migration",
+        "mlops",
+        "pipelines",
+        "orchestration",
+        "aws"
       ]
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,66 @@ No automated test framework is configured here. Treat structure validation as re
 - Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
 - Migration report includes a "Notebook Refactoring Summary" section unique to this skill.
 
+### zenml-argo-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- The core Argo migration challenge is Kubernetes-native workflow semantics: YAML CRDs, pod topology, status-based dependency logic, and volume/sidecar assumptions do not map 1:1 to ZenML's Python artifact-DAG model.
+- Treat enhanced `depends`, `containerSet`, shared PVC / `emptyDir` contracts, sidecars, synchronization locks, and Argo Events graphs as redesign-first patterns rather than safe auto-translations.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation or community escalation for genuine feature gaps.
+
+### zenml-prefect-migration
+- Same three-reference-file architecture as the airflow-migration and databricks-migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- The core Prefect migration challenge is semantic, not syntactic: dynamic execution, state inspection, and control-plane features do not map 1:1 to ZenML's artifact-DAG model.
+- Always classify runtime branching, runtime fan-out, `return_state=True`, `allow_failure()`, pause/suspend, task-runner semantics, global concurrency/rate limiting, and transaction patterns explicitly.
+- Treat Blocks as a decomposition problem (secrets + service connectors + stack config + YAML/params), not a single-object mapping.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
+
+### zenml-azureml-migration
+- Same three-reference-file architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`) with SKILL.md staying workflow-focused.
+- The skill is explicitly scoped to **Azure Machine Learning SDK v2**. If source material is still on SDK v1, normalize to v2 concepts before attempting a ZenML migration.
+- The skill treats the "keep AzureML" path as first-class: ZenML authors the workflow while AzureML can remain the execution plane through the AzureML orchestrator.
+- Preserve explicit caveats around unsafe control-flow auto-translation (`if_else`, `do_while`, `parallel_for`, `set_pipeline_controller_configurations`) and do not present them as safe 1:1 migrations.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, optionally routes deeper customization to `zenml-pipeline-authoring`, and offers GitHub issue creation for genuine feature gaps.
+
+### zenml-dagster-migration
+- Same three-reference-file architecture as the airflow-migration and databricks-migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- The core Dagster migration challenge is semantic, not syntactic: asset graphs and materialization boundaries do not map 1:1 to ZenML pipeline execution boundaries.
+- The skill requires an explicit pipeline-boundary decision before code generation: single pipeline, multiple pipelines, or partial migration plus redesign report.
+- The `gaps-and-flags.md` reference is especially important for IO managers with business logic, partitions/backfills, sensors, declarative automation, freshness policies, and asset-selection semantics.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
+- Migration report includes a "Pipeline Boundary Decisions" section unique to this skill.
+
+### zenml-flyte-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- The core Flyte migration challenge is preserving typed workflow contracts and registered-execution semantics while translating `@dynamic`, `map_task()`, `conditional()`, `LaunchPlan`, and special transport types (`FlyteFile`, `StructuredDataset`, `FlyteSchema`).
+- Treat `@eager`, `ContainerTask`, reference entities, checkpointing, interruptible semantics, and Union-specific features as redesign-first or high-caveat patterns.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
+
+### zenml-kedro-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- The hard part of Kedro migration is not node code but the Data Catalog contract: loader/exporter boundaries, dataset configuration, versioning, credentials, and operational semantics must become explicit in ZenML.
+- Preserve explicit caveats around transcoding, dataset lifecycle hooks, namespace/remapping behavior, slicing semantics, and shared-memory runner assumptions.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
+
+### zenml-metaflow-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- Metaflow is superficially close to ZenML, so the main danger is silent approximation: `self.*` artifact propagation, join semantics, `foreach`, `merge_artifacts`, `@catch`, resume/checkpoint behavior, and Outerbounds features must be classified explicitly.
+- Dynamic-pipeline translations should stay honest about orchestrator support and the `.load()` vs `.chunk(idx)` distinction when manual dynamic loops are involved.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation or community escalation for genuine feature gaps.
+
+### zenml-sagemaker-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- Centers the "keep SageMaker, change the authoring model" migration path: ZenML `@pipeline` / `@step` authoring with the SageMaker orchestrator and `SagemakerOrchestratorSettings` when the user wants to preserve AWS-native runtime behavior.
+- Handles SageMaker-specific challenges: step-type DSL migration (`ProcessingStep`, `TrainingStep`, `ConditionStep`, `TuningStep`, `TransformStep`, `ModelStep`), placeholder/data-model rewrites (`PropertyFile`, `JsonGet`, step `.properties`), and AWS-service-coupled steps (`CallbackStep`, `LambdaStep`, Clarify, Model Monitor, EMR, Notebook Jobs, Autopilot).
+- The `gaps-and-flags.md` reference is the safety layer for high-risk semantic mismatches such as dynamic-pipeline scheduling on the SageMaker orchestrator, Model Registry vs ZenML MCP, Feature Store parity claims, and warm-pool / output-mode trade-offs.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation or community escalation for genuine feature gaps.
+- Migration report includes a "SageMaker Runtime Mapping" section to make the keep-SageMaker runtime choices explicit.
+
+### zenml-vertexai-migration
+- Uses the same three-reference-file progressive-disclosure architecture as the other migration skills (`references/concept-map.md`, `references/code-patterns.md`, `references/gaps-and-flags.md`).
+- Centers the "keep Vertex as execution plane, adopt ZenML as control plane" migration path: prefer ZenML-native rewrites on the Vertex orchestrator, with black-box `PipelineJob` wrapping only as an explicitly documented fallback.
+- Treat artifact path/URI contracts, GCPC operators, compiled-template workflows, `dsl.ExitHandler`, and schedule-lifecycle parity as high-caveat or redesign-first areas.
+- Post-migration, chains to `zenml-quick-wins`, suggests `/simplify`, and offers GitHub issue creation for genuine feature gaps.
+
 ## Commit & Pull Request Guidelines
 Recent commits use short, imperative subjects (for example: `Add zenml-scoping...`, `Fix plugin agent format...`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,16 @@ This is the **ZenML Skills Marketplace** — a collection of modular AI coding a
 | `zenml-scoping` | Scope and decompose ML workflow ideas into realistic ZenML pipeline architectures via an interview process |
 | `zenml-pipeline-authoring` | Author ZenML pipelines with steps, artifacts, Docker settings, materializers, YAML config, and more |
 | `zenml-airflow-migration` | Migrate Apache Airflow DAGs to idiomatic ZenML pipelines with concept mapping, code translation, and unsupported pattern flagging |
+| `zenml-argo-migration` | Migrate Argo Workflows to idiomatic ZenML pipelines with concept mapping, code translation, Kubernetes-native pattern flagging, and redesign guidance |
 | `zenml-databricks-migration` | Migrate Databricks Workflows (Lakeflow Jobs) to idiomatic ZenML pipelines with notebook refactoring, concept mapping, code translation, and unsupported pattern flagging |
+| `zenml-prefect-migration` | Migrate Prefect flows and workflows to idiomatic ZenML pipelines with concept mapping, dynamic-execution analysis, code translation, and unsupported pattern flagging |
+| `zenml-azureml-migration` | Migrate Azure Machine Learning SDK v2 pipelines to idiomatic ZenML pipelines with concept mapping, Azure-aware compute translation, code patterns, and unsupported pattern flagging |
+| `zenml-dagster-migration` | Migrate Dagster assets, ops, jobs, and asset-graph workflows to idiomatic ZenML pipelines with concept mapping, pipeline-boundary planning, code translation, and unsupported pattern flagging |
+| `zenml-flyte-migration` | Migrate Flyte workflows, tasks, and LaunchPlans to idiomatic ZenML pipelines with concept mapping, special-type planning, code translation, and unsupported pattern flagging |
+| `zenml-kedro-migration` | Migrate Kedro pipelines and projects to idiomatic ZenML pipelines with Data Catalog to artifact translation, concept mapping, code translation, and unsupported pattern flagging |
+| `zenml-metaflow-migration` | Migrate Metaflow flows to idiomatic ZenML pipelines with FlowSpec mapping, artifact translation, control-flow redesign notes, and unsupported pattern flagging |
+| `zenml-sagemaker-migration` | Migrate Amazon SageMaker Pipelines to idiomatic ZenML pipelines with concept mapping, artifact-model rewrites, runtime-setting translation, and unsupported pattern flagging |
+| `zenml-vertexai-migration` | Migrate Vertex AI Pipelines (KFP v2 / PipelineJob workflows) to idiomatic ZenML pipelines with concept mapping, artifact-contract translation, GCPC rewrite guidance, and unsupported pattern flagging |
 
 ## Architecture
 
@@ -57,10 +66,91 @@ skills/
           concept-map.md
           code-patterns.md
           gaps-and-flags.md
+  zenml-argo-migration/
+    plugin.json
+    skills/
+      argo-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
   zenml-databricks-migration/
     plugin.json
     skills/
       databricks-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-prefect-migration/
+    plugin.json
+    skills/
+      prefect-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-vertexai-migration/
+    plugin.json
+    skills/
+      vertexai-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-azureml-migration/
+    plugin.json
+    skills/
+      azureml-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-dagster-migration/
+    plugin.json
+    skills/
+      dagster-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-flyte-migration/
+    plugin.json
+    skills/
+      flyte-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-kedro-migration/
+    plugin.json
+    skills/
+      kedro-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-metaflow-migration/
+    plugin.json
+    skills/
+      metaflow-migration/
+        SKILL.md
+        references/
+          concept-map.md
+          code-patterns.md
+          gaps-and-flags.md
+  zenml-sagemaker-migration/
+    plugin.json
+    skills/
+      sagemaker-migration/
         SKILL.md
         references/
           concept-map.md
@@ -142,4 +232,3 @@ Anthropic has great documentation and if you're doing something that relates to 
 ## Development Notes & Working with this repository
 
 IMPORTANT: **Before opening a PR or making a large commit**, always run `/simplify` to review changed code for reuse opportunities, quality issues, and efficiency improvements. Fix any issues it finds before committing.
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ $skill-installer install the zenml skills from github.com/zenml-io/skills
 | `zenml-scoping` | Scope and decompose ML workflow ideas into realistic ZenML pipeline architectures through a structured interview process | `/plugin install zenml-scoping@zenml` |
 | `zenml-pipeline-authoring` | Author ZenML pipelines with steps, artifacts, Docker settings, materializers, metadata, secrets, YAML config, and visualizations | `/plugin install zenml-pipeline-authoring@zenml` |
 | `zenml-airflow-migration` | Migrate Apache Airflow DAGs to idiomatic ZenML pipelines with concept mapping, code translation, severity-classified flagging, and redesign suggestions | `/plugin install zenml-airflow-migration@zenml` |
+| `zenml-argo-migration` | Migrate Argo Workflows to idiomatic ZenML pipelines with concept mapping, code translation, Kubernetes-native pattern flagging, and redesign guidance | `/plugin install zenml-argo-migration@zenml` |
 | `zenml-databricks-migration` | Migrate Databricks Workflows (Lakeflow Jobs) to idiomatic ZenML pipelines with notebook refactoring, concept mapping, code translation, and unsupported pattern flagging | `/plugin install zenml-databricks-migration@zenml` |
+| `zenml-prefect-migration` | Migrate Prefect flows and workflows to idiomatic ZenML pipelines with concept mapping, dynamic-execution analysis, code translation, and unsupported pattern flagging | `/plugin install zenml-prefect-migration@zenml` |
+| `zenml-vertexai-migration` | Migrate Vertex AI Pipelines (KFP v2 / PipelineJob workflows) to idiomatic ZenML pipelines with concept mapping, artifact-contract translation, GCPC rewrite guidance, and unsupported pattern flagging | `/plugin install zenml-vertexai-migration@zenml` |
+| `zenml-azureml-migration` | Migrate Azure Machine Learning SDK v2 pipelines to idiomatic ZenML pipelines with concept mapping, Azure-aware compute translation, code patterns, and unsupported pattern flagging | `/plugin install zenml-azureml-migration@zenml` |
+| `zenml-dagster-migration` | Migrate Dagster assets, ops, jobs, and asset-graph workflows to idiomatic ZenML pipelines with concept mapping, pipeline-boundary planning, code translation, and unsupported pattern flagging | `/plugin install zenml-dagster-migration@zenml` |
+| `zenml-flyte-migration` | Migrate Flyte workflows, tasks, and LaunchPlans to idiomatic ZenML pipelines with concept mapping, special-type planning, code translation, and unsupported pattern flagging | `/plugin install zenml-flyte-migration@zenml` |
+| `zenml-kedro-migration` | Migrate Kedro pipelines and projects to idiomatic ZenML pipelines with Data Catalog to artifact translation, concept mapping, code translation, and unsupported pattern flagging | `/plugin install zenml-kedro-migration@zenml` |
+| `zenml-metaflow-migration` | Migrate Metaflow flows to idiomatic ZenML pipelines with FlowSpec mapping, artifact translation, control-flow redesign notes, and unsupported pattern flagging | `/plugin install zenml-metaflow-migration@zenml` |
+| `zenml-sagemaker-migration` | Migrate Amazon SageMaker Pipelines to idiomatic ZenML pipelines with concept mapping, artifact-model rewrites, runtime-setting translation, and unsupported pattern flagging | `/plugin install zenml-sagemaker-migration@zenml` |
 
 ## Coming Soon
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,27 @@ $skill-installer install the zenml skills from github.com/zenml-io/skills
 
 ## Available Skills
 
+### Core Skills
+
 | Skill | Description | Install |
 |-------|-------------|---------|
 | `zenml-quick-wins` | Analyze your setup, recommend high-impact improvements, and implement features like metadata logging, experiment tracking, alerts, and model governance | `/plugin install zenml-quick-wins@zenml` |
 | `zenml-scoping` | Scope and decompose ML workflow ideas into realistic ZenML pipeline architectures through a structured interview process | `/plugin install zenml-scoping@zenml` |
 | `zenml-pipeline-authoring` | Author ZenML pipelines with steps, artifacts, Docker settings, materializers, metadata, secrets, YAML config, and visualizations | `/plugin install zenml-pipeline-authoring@zenml` |
+
+### Migration Skills
+
+These skills are best used when you already have real source material from another workflow system — code, YAML, JSON job specs, pipeline definitions, or project config — and you want help translating it into **idiomatic ZenML** rather than doing a superficial syntax swap.
+
+A few important caveats:
+
+- They classify source concepts as **direct**, **approximate**, or **unsupported** rather than pretending every platform feature has a safe 1:1 ZenML equivalent.
+- They are most helpful when you can provide the actual workflow code/config, not just a vague description.
+- Some migrations will be **partial by design**: the skill may generate working ZenML code for the cleanly mappable parts and a migration report for the pieces that need redesign.
+- After a migration, the best follow-up is usually `zenml-quick-wins` for production improvements and `zenml-pipeline-authoring` for deeper customization.
+
+| Skill | Description | Install |
+|-------|-------------|---------|
 | `zenml-airflow-migration` | Migrate Apache Airflow DAGs to idiomatic ZenML pipelines with concept mapping, code translation, severity-classified flagging, and redesign suggestions | `/plugin install zenml-airflow-migration@zenml` |
 | `zenml-argo-migration` | Migrate Argo Workflows to idiomatic ZenML pipelines with concept mapping, code translation, Kubernetes-native pattern flagging, and redesign guidance | `/plugin install zenml-argo-migration@zenml` |
 | `zenml-databricks-migration` | Migrate Databricks Workflows (Lakeflow Jobs) to idiomatic ZenML pipelines with notebook refactoring, concept mapping, code translation, and unsupported pattern flagging | `/plugin install zenml-databricks-migration@zenml` |

--- a/skills/zenml-airflow-migration/skills/airflow-migration/references/concept-map.md
+++ b/skills/zenml-airflow-migration/skills/airflow-migration/references/concept-map.md
@@ -45,17 +45,23 @@ Complete mapping of Airflow concepts to their ZenML equivalents. Each entry is c
 
 Not all ZenML orchestrators support scheduling. Check this before migrating scheduled DAGs:
 
-| Orchestrator | Scheduling | Types Supported |
-|---|:---:|---|
-| Kubernetes | Yes | Cron |
-| Vertex AI | Yes | Cron |
-| SageMaker | Yes | Cron, Interval, One-time |
-| AzureML | Yes | Cron, Interval |
-| Airflow (as ZenML orchestrator) | Yes | Cron, Interval |
-| Kubeflow | Yes | Cron, Interval |
-| Databricks | Yes | Cron only |
-| Local / LocalDocker | No | — |
-| SkyPilot | No | — |
+| Orchestrator | Scheduling Support | Supported Schedule Types | Native Schedule Management |
+|---|:---:|---|:---:|
+| AirflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| AzureMLOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| DatabricksOrchestrator | ✅ | Cron only | ⛔️ |
+| HyperAIOrchestrator | ✅ | Cron, One-time | ⛔️ |
+| KubeflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| KubernetesOrchestrator | ✅ | Cron only | ✅ |
+| LocalOrchestrator | ⛔️ | N/A | N/A |
+| LocalDockerOrchestrator | ⛔️ | N/A | N/A |
+| SagemakerOrchestrator | ✅ | Cron, Interval, One-time | ⛔️ |
+| SkypilotAWSOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotAzureOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotGCPOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotLambdaOrchestrator | ⛔️ | N/A | N/A |
+| TektonOrchestrator | ⛔️ | N/A | N/A |
+| VertexOrchestrator | ✅ | Cron only | ⛔️ |
 
 ## Data Passing and Parameters
 

--- a/skills/zenml-argo-migration/plugin.json
+++ b/skills/zenml-argo-migration/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "zenml-argo-migration",
+  "version": "1.0.0",
+  "description": "Migrate Argo Workflows to idiomatic ZenML pipelines with concept mapping, code translation, Kubernetes-native pattern flagging, and redesign guidance",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "argo",
+    "argo-workflows",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration",
+    "kubernetes"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-argo-migration/skills/argo-migration/SKILL.md
+++ b/skills/zenml-argo-migration/skills/argo-migration/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: argo-to-zenml-migration
+description: >-
+  Migrate Argo Workflows, WorkflowTemplates, ClusterWorkflowTemplates, and
+  CronWorkflows to idiomatic ZenML pipelines. Handles concept mapping,
+  YAML-to-Python translation, scheduling, retries, Kubernetes-native pattern
+  analysis, and flags unsupported patterns such as status-based depends logic,
+  shared volumes, containerSet, sidecars, synchronization locks, and Argo
+  Events for human review. Use this skill whenever the user mentions Argo
+  migration, converting Argo YAML, replacing Argo with ZenML, mapping an Argo
+  concept to ZenML, or provides workflow YAML using terms like
+  WorkflowTemplate, CronWorkflow, when, withItems, withParam, containerSet,
+  onExit, Sensor, or EventSource. For quick conceptual questions, answer from
+  the concept map without running the full migration workflow.
+---
+
+# Migrate Argo Workflows to ZenML
+
+This skill translates Argo Workflows into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing Argo YAML and referenced scripts, classifying each pattern, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project.
+
+## How migration works at a high level
+
+Argo and ZenML can both express DAG-shaped workflows, but they speak different native languages.
+
+- **Argo** is a Kubernetes-native workflow engine driven by YAML CRDs, template references, variable substitution, pod topology, and controller policies.
+- **ZenML** is a Python-first pipeline framework driven by `@step`, `@pipeline`, typed artifacts, stack components, and orchestrator-managed execution.
+
+That means this migration is not a simple rename operation. Some Argo features map well, some only preserve intent, and some depend so heavily on controller or pod semantics that they must be redesigned explicitly.
+
+### The three mapping types
+
+Every Argo concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 or near-1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in the migration report |
+| **Absent** | No ZenML equivalent exists | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Argo Workflow
+
+Ask the user for all relevant migration inputs. At minimum, request:
+
+- the Argo YAML manifests (`Workflow`, `WorkflowTemplate`, `ClusterWorkflowTemplate`, `CronWorkflow`)
+- any referenced scripts, Python modules, container commands, or shell scripts
+- any EventSource / Sensor / trigger definitions if Argo Events is involved
+- any Kubernetes resources the workflow depends on (PVCs, service accounts, secrets, ConfigMaps, pod-spec patches)
+- any assumptions about cluster-local files, mounted volumes, or helper containers
+
+Read everything thoroughly before doing anything else. For each workflow, identify:
+
+1. **Object kinds** -- `Workflow`, `WorkflowTemplate`, `ClusterWorkflowTemplate`, `CronWorkflow`, `EventSource`, `Sensor`
+2. **Template types** -- `container`, `script`, `dag`, `steps`, `resource`, `http`, `suspend`, `plugin`, `data`, `containerSet`
+3. **Dependencies** -- `dependencies`, enhanced `depends`, `templateRef`, `workflowTemplateRef`, workflow-of-workflows patterns
+4. **Data flow** -- workflow parameters, input parameters, output parameters from files, `outputs.result`, artifacts, `globalName`
+5. **Control flow** -- `when`, `withItems`, `withParam`, `withSequence`, `continueOn`, `onExit`, lifecycle hooks
+6. **Execution policies** -- retries, backoff, deadlines, memoization, synchronization, fail-fast settings
+7. **Kubernetes coupling** -- shared volumes, PVC templates, `emptyDir`, sidecars, init containers, node selectors, affinity, tolerations, service accounts
+8. **Scheduling and triggers** -- `CronWorkflow` schedules, concurrency policy, timezone, Argo Events integration
+9. **Runtime contract** -- whether a template is really value-based, path-based, or same-pod / same-filesystem coupled
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it using the mapping type (direct / approximate / absent). Use the decision logic below and the full tables in [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+**Direct or near-direct translations (translate automatically):**
+- workflow parameters -> pipeline parameters
+- template input parameters -> step function arguments
+- simple `dag` success-path dependencies -> pipeline step wiring
+- `withSequence` -> Python `range(...)` in a dynamic pipeline
+- retry count/delay -> `StepRetryConfig(...)`
+- memoization intent -> ZenML caching
+
+**Approximate translations (translate with caveats):**
+- `Workflow` / `WorkflowTemplate` -> `@pipeline` plus a pipeline run or reusable Python module
+- `CronWorkflow` -> `Schedule(...)` on a supported orchestrator
+- `container` / `script` template -> `@step` with Python logic, `DockerSettings`, or `subprocess.run(...)`
+- output parameter via file or `outputs.result` -> explicit step return value
+- artifact passing -> ZenML artifacts and materializers
+- `when` on values -> dynamic pipeline branching or explicit soft-conditional logic
+- `withItems` / `withParam` -> dynamic fanout using real list artifacts and `.map()`
+- `onExit` -> redesign using hooks, idempotent cleanup, execution modes, or external cleanup control
+- `resource` / `http` templates -> explicit SDK or API calls inside steps
+- Kubernetes resources / placement settings -> orchestrator-specific settings documented as portability loss
+
+**Absent / redesign-first patterns (flag for human review):**
+- enhanced `depends` expressions based on task status (`A.Failed`, `B.Errored`, etc.)
+- `containerSet`
+- `suspend` templates unless the target project is on a recent 0.94.x release with `zenml.wait(...)` support (preferably `>=0.94.1`), and even then only as an explicit redesign
+- shared PVC / `emptyDir` filesystem contracts across steps
+- sidecars, daemon containers, and same-pod helper services
+- synchronization mutexes / semaphores
+- Argo Events graphs (`EventSource` + `Sensor` + dependency logic)
+- non-Python arbitrary images that cannot be sensibly wrapped in a Python-capable ZenML step environment
+
+#### Present the migration plan
+
+Before writing any code, present a summary to the user:
+
+> "Here's what I found in your Argo workflow:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with noted caveats): [list]
+> - **Needs redesign** (cannot auto-migrate): [list with brief explanation]
+>
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain each one concretely: what the Argo workflow does, why ZenML cannot reproduce it directly, and what the redesign options look like.
+
+### Phase 3: Generate ZenML Code
+
+Translate the Argo workflow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── transform.py
+│   └── load.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Custom materializers (if needed)
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+This matches the `zenml-pipeline-authoring` skill's conventions. Key rules:
+
+- one step per file in `steps/`
+- separate pipeline definition from execution
+- `run.py` uses `argparse` (click conflicts with ZenML)
+- `pyproject.toml` uses `requires-python = ">=3.12"` and `zenml>=0.94.1` as the dependency floor
+- always generate `configs/dev.yaml` and `configs/prod.yaml`
+- always generate a `README.md` explaining what was migrated and what still needs manual attention
+- include concise migration comments in code, not essay-length explanations
+- run `zenml init` at the project root
+
+#### Translation patterns
+
+See [references/code-patterns.md](references/code-patterns.md) for side-by-side examples covering DAGs, steps templates, loops, conditionals, artifacts, CronWorkflows, exit handlers, shared-volume redesigns, and Argo Events integration patterns.
+
+**The core translation rule**: move business logic out of YAML templates and into typed Python functions. Treat the YAML graph as a description of orchestration, then rebuild that orchestration in Python using step calls and artifact wiring.
+
+```python
+# Argo mental model
+# template "extract" writes a value to a file or stdout
+
+# ZenML translation
+@step
+def extract() -> list[int]:
+    return [1, 2, 3]
+```
+
+**Parameters -> function arguments**:
+
+```python
+@pipeline
+def training_pipeline(dataset: str, learning_rate: float = 0.1) -> None:
+    prepared = prepare_data(dataset=dataset)
+    train_model(data=prepared, learning_rate=learning_rate)
+```
+
+**Output files / `outputs.result` -> step returns**:
+
+```python
+@step
+def read_threshold() -> float:
+    # Migration note: Argo previously read this from `valueFrom.path`.
+    # ZenML treats the extracted value as a normal typed return.
+    return 0.8
+```
+
+**File artifacts -> typed artifacts or explicit `Path` contracts**:
+
+```python
+from pathlib import Path
+
+@step
+def produce_manifest() -> Path:
+    output = Path("/tmp/manifest.json")
+    output.write_text("{\"ok\": true}")
+    return output
+```
+
+Use a file- or path-based contract only when the original workflow genuinely depends on file identity or layout. Otherwise prefer typed domain objects.
+
+**CronWorkflow -> Schedule**:
+
+```python
+from zenml.config.schedule import Schedule
+
+schedule = Schedule(cron_expression="0 2 * * *")
+my_pipeline.with_options(schedule=schedule)()
+```
+
+Always note that scheduling is orchestrator-dependent and that CronWorkflow-specific behavior like timezone and concurrency policy may need extra handling.
+
+**Suspend / pause-resume note**:
+
+If the source workflow uses `suspend`, do not present ZenML wait/resume as a generic drop-in replacement. Treat it as a redesign option that requires a recent 0.94.x release -- preferably `zenml>=0.94.1`, where `zenml.wait(...)` and pipeline run resume are documented in the official changelog.
+
+#### Code comment style
+
+Keep migration-related comments short and actionable:
+
+- use `# Migration note:` for brief inline caveats
+- use `# TODO(migration):` for unsupported patterns or manual follow-up
+- keep long explanations in the migration report, not in code
+
+#### Handling approximate translations
+
+When translating approximate patterns, add a brief note explaining the semantic shift:
+
+```python
+@step
+def run_cli(command: list[str]) -> str:
+    # Migration note: Argo container templates can run any image + command.
+    # This ZenML step runs in a Python-capable environment and wraps the CLI
+    # with subprocess. Verify tooling is present in the step image.
+    import subprocess
+
+    completed = subprocess.run(command, check=True, text=True, capture_output=True)
+    return completed.stdout
+```
+
+#### Handling absent patterns
+
+For patterns that have no ZenML equivalent, do NOT silently approximate them. Instead:
+
+1. add a clearly marked `# TODO(migration)` comment in the generated code
+2. include the pattern in the migration report
+3. suggest a redesign approach
+
+```python
+# TODO(migration): UNSUPPORTED -- Argo enhanced depends expression
+# `cleanup` previously ran when `train.Failed || validate.Errored`.
+# ZenML cannot branch on upstream failure states this way. Redesign with
+# explicit status artifacts, hooks, or separate alerting/cleanup flows.
+@step
+def cleanup_after_failure(status: dict[str, bool]) -> None:
+    ...
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root.
+
+```markdown
+# Migration Report: [Argo Workflow] -> [ZenML Pipeline]
+
+## Summary
+- **Source**: Argo `[kind]` `[name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Templates migrated**: X direct, Y approximate, Z flagged
+
+## Direct Translations
+| Argo Template / Concept | ZenML Equivalent | Notes |
+|---|---|---|
+| parameters | pipeline args | Clean translation |
+
+## Approximate Translations
+| Argo Template / Concept | ZenML Equivalent | What Changed |
+|---|---|---|
+| CronWorkflow | Schedule(...) | Schedule support depends on orchestrator; concurrency policy may need extra handling |
+
+## Flagged for Review
+| Argo Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| containerSet | HIGH | No multi-container same-pod primitive in ZenML | Collapse into one step or externalize to Kubernetes-native service |
+
+## Scheduling
+- **Original**: CronWorkflow `0 2 * * *`, timezone `UTC`
+- **Migrated**: `Schedule(cron_expression="0 2 * * *")`
+- **Note**: Verify orchestrator scheduling support and any concurrency / timezone semantics
+
+## Kubernetes-Native / Infrastructure Assumptions
+| Original Argo Assumption | Migration Status | Notes |
+|---|---|---|
+| Shared PVC | Flagged | Redesign around artifacts or explicit external storage |
+
+## Limitations and Key Differences
+[Summarize the most important semantic shifts before listing benefits.]
+
+## What's NOT Migrated
+[List Argo features outside the portable ZenML scope: Sensors, EventSources, cluster policy, sidecars, etc.]
+
+## What You Get for Free After Migration
+- typed artifacts and artifact lineage
+- step caching
+- stack abstraction
+- service connectors and secrets management
+- Model Control Plane for ML workflows
+
+## Recommended Next Steps
+1. Run the `zenml-quick-wins` skill
+2. Install the ZenML docs MCP server
+3. Review every HIGH-severity redesign item
+4. Use the `zenml-pipeline-authoring` skill for Docker settings, custom materializers, deployment, or deeper configuration
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a "Recommended Next Steps" section in the migration report AND communicate it to the user.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+Always suggest this as the immediate next step:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerters, and other production-readiness features."
+
+#### 2. Documentation links for flagged patterns
+
+For every flagged pattern, include a link to the relevant ZenML documentation:
+
+- Scheduling: `https://docs.zenml.io/how-to/steps-pipelines/schedule-a-pipeline`
+- Dynamic pipelines: `https://docs.zenml.io/how-to/steps-pipelines/dynamic-pipelines`
+- Triggers and event-driven pipelines: `https://docs.zenml.io/how-to/steps-pipelines/trigger-a-pipeline`
+- Orchestrators: `https://docs.zenml.io/stacks/stack-components/orchestrators`
+- Containerization: `https://docs.zenml.io/how-to/containerization/containerization`
+- Secrets management: `https://docs.zenml.io/how-to/project-setup-and-management/secret-management`
+- Service connectors / auth: `https://docs.zenml.io/how-to/infrastructure-deployment/auth-management`
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML documentation while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Community support for unsupported patterns
+
+When the migration has HIGH-severity flags, offer to help the user get support from the ZenML community.
+
+**When there are 2+ HIGH-severity flags**, generate a pre-made Slack message for `zenml.io/slack` that includes:
+
+- what they are migrating
+- the unsupported Argo patterns
+- a short code snippet for each relevant pattern
+- what redesign ideas were already considered
+- a clear ask for better approaches or feature guidance
+
+```markdown
+**Argo -> ZenML Migration Help**
+
+I'm migrating an Argo Workflow that uses [patterns]. The migration skill flagged these as needing redesign:
+
+1. **[Pattern]**: [brief description + Argo snippet]
+   - Suggested workaround: [X]
+
+2. **[Pattern]**: [brief description + Argo snippet]
+   - Suggested workaround: [Y]
+
+I'm looking for advice on whether there is a better ZenML-native pattern or an upcoming feature that would fit this use case.
+```
+
+#### 5. Open GitHub issues for genuine feature gaps
+
+When the migration reveals a real missing feature in ZenML, offer to open a GitHub issue on `zenml-io/zenml` using `gh issue create`. Include the Argo pattern, why it matters, what workaround was attempted, and why the gap is broadly useful.
+
+#### 6. Run `/simplify` to clean up the migrated code
+
+Always suggest running `/simplify` after the migration:
+
+> "The migration is done. I'd recommend running `/simplify` on the generated code to clean up migration comments, reduce duplication, and make the result feel more like native ZenML code."
+
+#### 7. Further customization via `zenml-pipeline-authoring`
+
+The `zenml-pipeline-authoring` skill handles deeper customization:
+
+- Docker settings for remote execution
+- YAML configuration for multi-environment setups
+- custom materializers for file or domain-specific contracts
+- pipeline deployments and serving
+
+## Important Behavioral Differences to Communicate
+
+These are the most common sources of confusion after migration. Always mention the relevant ones in the migration report.
+
+### Declarative YAML != imperative Python
+
+Argo YAML is the execution program. ZenML Python is the execution program. That means a migration rewrites orchestration into code; it does not merely reformat manifests.
+
+### File-based artifacts != typed artifacts
+
+In Argo, file paths, output files, and artifact repository wiring are often part of the workflow contract. In ZenML, the typed value is the contract, and storage is delegated to the artifact store plus materializers.
+
+### Kubernetes-native != stack-abstracted
+
+Argo assumes Kubernetes everywhere. ZenML can run on Kubernetes, but it treats Kubernetes as one execution backend among several. Pod-level settings need to be isolated as infrastructure concerns, not mixed into portable pipeline logic.
+
+### Shared volumes / same-pod semantics != isolated steps
+
+Argo patterns built around shared PVCs, `emptyDir`, sidecars, init containers, or same-pod container coordination do not map cleanly to independent ZenML steps. These are redesign hotspots.
+
+### Status-based control flow != value-based control flow
+
+Argo can branch on task result states directly. ZenML control flow is much more naturally expressed as value-based logic in Python. If the old behavior depends on failure states, model that explicitly and document the semantic change.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Translating YAML templates 1:1 into step files without redesigning data flow | Preserves Argo syntax shape but not ZenML semantics | Design step interfaces around typed args, returns, and artifacts |
+| Treating output parameters as ZenML pipeline parameters | Upstream-produced values are artifacts in ZenML | Return values from steps and wire them downstream |
+| Returning `/tmp/...` paths from one step and assuming another step can read them | ZenML steps are isolated; local paths are not stable contracts | Return typed data, or explicitly model a file / URI contract |
+| Reusing arbitrary non-Python images unchanged | ZenML step execution still expects a Python-capable runtime | Build a Python-capable image or keep that execution outside ZenML |
+| Translating `depends: "A.Failed"` into a naive Python `if` after `A()` | A failing ZenML step changes run behavior; it is not just a boolean value | Model failure as data, use hooks, or split flows |
+| Replacing shared-volume logic with `/tmp` across multiple steps | `/tmp` is container-local, not workflow-global | Collapse into one step or externalize state |
+| Rewriting `withParam` as JSON strings passed between steps | Keeps Argo's serialization hack and loses ZenML typing | Return real `list[...]` artifacts and fan out dynamically |
+| Mapping `onExit` to a success hook | Success hooks do not behave like workflow finalizers | Use `try/finally`, failure hooks, or external cleanup orchestration |
+| Claiming Argo Events maps directly to native ZenML event graphs | Public ZenML docs do not describe Argo-Events-style parity | Use external event infrastructure to invoke ZenML runs |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- full concept mapping tables for Argo objects, template types, data passing, control flow, execution features, Kubernetes-native features, and Argo Events
+- [references/code-patterns.md](references/code-patterns.md) -- side-by-side translation examples for the most common Argo migration patterns
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- must-flag patterns, behavioral differences, template classification, and the migration decision tree
+
+### ZenML documentation
+
+For topics beyond migration (stack setup, experiment tracking, deployment, or orchestrator setup), query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-argo-migration/skills/argo-migration/references/code-patterns.md
+++ b/skills/zenml-argo-migration/skills/argo-migration/references/code-patterns.md
@@ -1,0 +1,735 @@
+# Argo Workflows -> ZenML Code Translation Patterns
+
+This reference shows side-by-side translation patterns for the most common Argo migration cases. Use these examples as **shape guides**, not as a promise of perfect 1:1 semantics.
+
+## Table of Contents
+
+- [Simple DAG template with dependencies](#simple-dag-template-with-dependencies)
+- [Steps template with sequential and parallel groups](#steps-template-with-sequential-and-parallel-groups)
+- [Container template for arbitrary image execution](#container-template-for-arbitrary-image-execution)
+- [Script template for inline Python or shell](#script-template-for-inline-python-or-shell)
+- [Parameter passing between templates](#parameter-passing-between-templates)
+- [Artifact passing between templates](#artifact-passing-between-templates)
+- [Conditional execution with `when`](#conditional-execution-with-when)
+- [Loops: `withSequence`, `withItems`, `withParam`](#loops-withsequence-withitems-withparam)
+- [Retry strategy with backoff](#retry-strategy-with-backoff)
+- [Exit handler with `onExit`](#exit-handler-with-onexit)
+- [CronWorkflow scheduling](#cronworkflow-scheduling)
+- [Shared volume / PVC redesign](#shared-volume--pvc-redesign)
+- [ContainerSet redesign](#containerset-redesign)
+- [Argo Events integration](#argo-events-integration)
+
+## Simple DAG template with dependencies
+
+### Argo YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: etl-
+spec:
+  entrypoint: etl
+  templates:
+    - name: etl
+      dag:
+        tasks:
+          - name: extract
+            template: extract
+          - name: transform
+            dependencies: [extract]
+            template: transform
+          - name: load
+            dependencies: [transform]
+            template: load
+
+    - name: extract
+      script:
+        image: python:3.12
+        command: [python]
+        source: |
+          print("extract")
+
+    - name: transform
+      script:
+        image: python:3.12
+        command: [python]
+        source: |
+          print("transform")
+
+    - name: load
+      script:
+        image: python:3.12
+        command: [python]
+        source: |
+          print("load")
+```
+
+### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def extract() -> str:
+    return "extract"
+
+
+@step
+def transform(value: str) -> str:
+    return f"{value}:transform"
+
+
+@step
+def load(value: str) -> None:
+    print(f"loading {value}")
+
+
+@pipeline
+def etl_pipeline() -> None:
+    raw = extract()
+    cooked = transform(raw)
+    load(cooked)
+```
+
+### Key differences
+
+- Argo dependencies are declared in YAML; ZenML dependencies are created by step calls and artifact wiring.
+- The ZenML version makes the data flow explicit instead of pointing to templates by name.
+
+### Migration warning
+
+This mapping stays clean only while the Argo DAG uses ordinary success-path dependencies. If it uses enhanced `depends` logic based on task status, treat it as redesign-first.
+
+## Steps template with sequential and parallel groups
+
+### Argo YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: prepare
+            template: prepare
+        - - name: score-a
+            template: score-a
+          - name: score-b
+            template: score-b
+        - - name: combine
+            template: combine
+
+    - name: prepare
+      script:
+        image: python:3.12
+        command: [python]
+        source: "print('prepare')"
+    - name: score-a
+      script:
+        image: python:3.12
+        command: [python]
+        source: "print('score-a')"
+    - name: score-b
+      script:
+        image: python:3.12
+        command: [python]
+        source: "print('score-b')"
+    - name: combine
+      script:
+        image: python:3.12
+        command: [python]
+        source: "print('combine')"
+```
+
+### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def prepare() -> list[int]:
+    return [1, 2, 3]
+
+
+@step
+def score_a(data: list[int]) -> int:
+    return sum(data)
+
+
+@step
+def score_b(data: list[int]) -> int:
+    return max(data)
+
+
+@step
+def combine(a: int, b: int) -> dict[str, int]:
+    return {"sum": a, "max": b}
+
+
+@pipeline
+def scoring_pipeline() -> None:
+    data = prepare()
+    a = score_a(data)
+    b = score_b(data)
+    combine(a, b)
+```
+
+### Key differences
+
+- Argo's outer array means sequence; inner array means potential parallelism.
+- In ZenML, concurrency is inferred from the dependency graph and depends on the active orchestrator.
+
+### Migration warning
+
+Do not promise true parallel execution on every orchestrator. The DAG shape maps, but actual parallelism is backend-dependent.
+
+## Container template for arbitrary image execution
+
+### Argo YAML
+
+```yaml
+- name: convert
+  container:
+    image: alpine:3.20
+    command: ["sh", "-c"]
+    args: ["cat /input/data.txt | tr a-z A-Z > /tmp/out.txt"]
+```
+
+### ZenML Python
+
+```python
+from pathlib import Path
+import subprocess
+
+from zenml import step
+
+
+@step
+def convert(input_path: Path) -> Path:
+    # Migration note: Argo container templates can use arbitrary images and
+    # commands. This ZenML step assumes the required CLI tools exist inside a
+    # Python-capable image.
+    output_path = Path("/tmp/out.txt")
+    cmd = f"cat {input_path} | tr a-z A-Z > {output_path}"
+    subprocess.run(["sh", "-c", cmd], check=True)
+    return output_path
+```
+
+### Migration warning
+
+If the original container image is the real unit of reproducibility and it is not Python-capable, do not pretend this is a clean migration. Either build a Python-capable image, wrap the tool carefully, or keep that node outside ZenML.
+
+## Script template for inline Python or shell
+
+### Argo YAML
+
+```yaml
+- name: train
+  script:
+    image: python:3.12
+    command: [python]
+    source: |
+      import json
+      print(json.dumps({"accuracy": 0.91}))
+```
+
+### ZenML Python
+
+```python
+from zenml import step
+
+
+@step
+def train() -> dict[str, float]:
+    return {"accuracy": 0.91}
+```
+
+### Migration warning
+
+Inline Python translates well. Inline shell should usually become `subprocess.run(...)` inside a step, with an explicit note about tool availability and container image requirements.
+
+## Parameter passing between templates
+
+### Argo YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: params-
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: dataset
+        value: customers
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: extract
+            template: extract
+            arguments:
+              parameters:
+                - name: dataset
+                  value: "{{workflow.parameters.dataset}}"
+    - name: extract
+      inputs:
+        parameters:
+          - name: dataset
+      script:
+        image: python:3.12
+        command: [python]
+        source: |
+          print("reading {{inputs.parameters.dataset}}")
+```
+
+### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def extract(dataset: str) -> str:
+    return f"reading {dataset}"
+
+
+@pipeline
+def extraction_pipeline(dataset: str = "customers") -> None:
+    extract(dataset=dataset)
+```
+
+### Key differences
+
+- Argo substitutes strings into YAML-managed variables.
+- ZenML passes typed Python values through function signatures.
+
+## Artifact passing between templates
+
+### Argo YAML
+
+```yaml
+- name: produce-report
+  script:
+    image: python:3.12
+    command: [python]
+    source: |
+      with open("/tmp/report.json", "w") as f:
+          f.write("{\"ok\": true}")
+  outputs:
+    artifacts:
+      - name: report
+        path: /tmp/report.json
+
+- name: consume-report
+  inputs:
+    artifacts:
+      - name: report
+        path: /tmp/input-report.json
+```
+
+### ZenML Python
+
+```python
+from pathlib import Path
+
+from zenml import pipeline, step
+
+
+@step
+def produce_report() -> Path:
+    report = Path("/tmp/report.json")
+    report.write_text('{"ok": true}')
+    return report
+
+
+@step
+def consume_report(report: Path) -> dict[str, bool]:
+    return {"report_exists": report.exists()}
+
+
+@pipeline
+def report_pipeline() -> None:
+    report = produce_report()
+    consume_report(report)
+```
+
+### Key differences
+
+- Argo treats files and artifact paths as first-class workflow wiring.
+- ZenML can preserve a file contract, but it is often better to return a typed object instead.
+
+### Migration warning
+
+Do not preserve a path contract by accident. Use `Path` or URI artifacts only when downstream logic truly depends on a file contract.
+
+## Conditional execution with `when`
+
+### Argo YAML
+
+```yaml
+- name: maybe-train
+  when: "{{workflow.parameters.should_train}} == true"
+  template: train
+```
+
+### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def train() -> str:
+    return "trained"
+
+
+@pipeline(dynamic=True)
+def training_pipeline(should_train: bool) -> None:
+    if should_train:
+        train()
+```
+
+### Migration warning
+
+This stays relatively clean when the condition is based on input values. If the condition depends on task status or on runtime outputs in a way that changes graph shape, classify it as approximate or absent and explain the semantic shift.
+
+## Loops: `withSequence`, `withItems`, `withParam`
+
+### `withSequence`
+
+#### Argo YAML
+
+```yaml
+- name: batch
+  template: process
+  withSequence:
+    count: "3"
+```
+
+#### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def process(i: int) -> int:
+    return i * 2
+
+
+@pipeline(dynamic=True)
+def loop_pipeline() -> None:
+    for i in range(3):
+        process(i)
+```
+
+### `withItems`
+
+#### Argo YAML
+
+```yaml
+- name: greet
+  template: hello
+  withItems:
+    - alex
+    - noa
+```
+
+#### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def produce_names() -> list[str]:
+    return ["alex", "noa"]
+
+
+@step
+def hello(name: str) -> str:
+    return f"hello {name}"
+
+
+@pipeline(dynamic=True)
+def greeting_pipeline() -> None:
+    names = produce_names()
+    hello.map(names)
+```
+
+### `withParam`
+
+#### Argo YAML
+
+```yaml
+- name: fanout
+  template: process
+  withParam: "{{steps.make-list.outputs.result}}"
+```
+
+#### ZenML Python
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def make_list() -> list[dict[str, int]]:
+    return [{"value": 1}, {"value": 2}, {"value": 3}]
+
+
+@step
+def process(item: dict[str, int]) -> int:
+    return item["value"] * 10
+
+
+@pipeline(dynamic=True)
+def fanout_pipeline() -> None:
+    items = make_list()
+    process.map(items)
+```
+
+### Migration warnings
+
+- Do not preserve `withParam` as "JSON in, JSON out." Return real typed lists.
+- Dynamic fanout semantics, failure handling, and concurrency depend on the orchestrator and differ from Argo's controller behavior.
+
+## Retry strategy with backoff
+
+### Argo YAML
+
+```yaml
+- name: flaky
+  retryStrategy:
+    limit: "3"
+    backoff:
+      duration: "10s"
+      factor: 2
+```
+
+### ZenML Python
+
+```python
+from zenml import step
+from zenml.config.retry_config import StepRetryConfig
+
+
+@step(retry=StepRetryConfig(max_retries=3, delay=10, backoff=2))
+def flaky() -> None:
+    ...
+```
+
+### Migration warning
+
+Argo retry policies and retry expressions are richer than ZenML's portable retry surface. If the original workflow uses policy-specific or expression-based retry behavior, flag it.
+
+## Exit handler with `onExit`
+
+### Argo YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-
+spec:
+  entrypoint: main
+  onExit: finalize
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: work
+            template: work
+    - name: finalize
+      script:
+        image: python:3.12
+        command: [python]
+        source: "print('always run cleanup')"
+```
+
+### ZenML Python (redesign sketch)
+
+```python
+from zenml import step
+
+
+@step
+def work_with_cleanup() -> None:
+    resource = acquire_resource()
+    try:
+        run_main_work(resource)
+    finally:
+        cleanup_resource(resource)
+```
+
+### Migration warning
+
+Do not equate `onExit` with a success hook, and do not quietly turn failures into `{ok: false}` data without calling that semantic change out explicitly. If the original Argo workflow depends on guaranteed workflow-level finalization, redesign that boundary on purpose:
+
+- move resource ownership into a single step with `try/finally` when possible
+- use hooks for notifications, not as finalizer substitutes
+- use external cleanup / monitoring when the finalization scope is larger than one step
+
+## CronWorkflow scheduling
+
+### Argo YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-report
+spec:
+  schedule: "0 2 * * *"
+  timezone: UTC
+  concurrencyPolicy: Forbid
+  workflowSpec:
+    entrypoint: report
+```
+
+### ZenML Python
+
+```python
+from zenml import pipeline
+from zenml.config.schedule import Schedule
+
+
+@pipeline
+def report_pipeline() -> None:
+    ...
+
+
+schedule = Schedule(cron_expression="0 2 * * *")
+report_pipeline.with_options(schedule=schedule)()
+```
+
+### Migration warning
+
+Do not assume `concurrencyPolicy: Forbid`, timezone behavior, and schedule lifecycle management map fully to `Schedule(...)`. Scheduling support is orchestrator-dependent, and some CronWorkflow semantics may need extra infrastructure decisions.
+
+## Shared volume / PVC redesign
+
+### Argo YAML
+
+```yaml
+spec:
+  volumes:
+    - name: workspace
+      persistentVolumeClaim:
+        claimName: shared-data
+  templates:
+    - name: write
+      container:
+        image: python:3.12
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+    - name: read
+      container:
+        image: python:3.12
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+```
+
+### ZenML Python
+
+```python
+from pathlib import Path
+
+from zenml import pipeline, step
+
+
+@step
+def write_dataset() -> Path:
+    path = Path("/tmp/dataset.parquet")
+    # write file here
+    return path
+
+
+@step
+def read_dataset(dataset_path: Path) -> None:
+    # consume the path or materialized artifact here
+    ...
+
+
+@pipeline
+def pvc_redesign_pipeline() -> None:
+    dataset = write_dataset()
+    read_dataset(dataset)
+```
+
+### Migration warning
+
+This is one of the most important redesign hotspots. Replacing a shared PVC with `/tmp` across multiple ZenML steps is simply wrong. Use typed artifacts, explicit `Path` artifacts, external object storage, or collapse tightly-coupled logic into one step.
+
+## ContainerSet redesign
+
+### Argo YAML
+
+```yaml
+- name: main
+  containerSet:
+    containers:
+      - name: downloader
+        image: alpine
+      - name: processor
+        image: python:3.12
+        dependencies: [downloader]
+```
+
+### ZenML Approach
+
+```python
+from zenml import step
+
+
+@step
+def download_and_process() -> None:
+    # Migration note: Argo containerSet ran multiple containers in one pod
+    # with cheap shared filesystem and network semantics. This redesign keeps
+    # the tightly coupled work inside one step boundary.
+    ...
+```
+
+### Migration warning
+
+Do not split a `containerSet` into several ZenML steps unless you also redesign the data and lifecycle contract. Same pod is not the same as several isolated step containers.
+
+## Argo Events integration
+
+### Argo Concepts
+
+- `EventSource` consumes external events
+- `Sensor` applies dependency logic
+- `Trigger` submits a workflow or another action
+
+### ZenML Mapping Sketch
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.post("/trigger")
+def trigger_pipeline(payload: dict) -> dict[str, str]:
+    # Migration note: external eventing is now the control plane.
+    # This endpoint would validate the event and invoke a ZenML deployment,
+    # pipeline run, or snapshot trigger through the appropriate API.
+    return {"status": "accepted"}
+```
+
+### Migration warning
+
+Argo Events is a platform-level event graph, not just a "trigger." In current ZenML docs, the safe story is still external event system -> deployment endpoint / pipeline run / snapshot trigger. ZenML does document a Pro `Trigger` concept, but the first supported trigger type is schedules, and legacy event-source APIs were removed in 0.94.0. Keep the event logic explicit instead of claiming full native parity.

--- a/skills/zenml-argo-migration/skills/argo-migration/references/concept-map.md
+++ b/skills/zenml-argo-migration/skills/argo-migration/references/concept-map.md
@@ -1,0 +1,147 @@
+# Argo Workflows -> ZenML Concept Map
+
+Complete mapping of Argo Workflows concepts to their ZenML equivalents. Each entry is classified as **direct** (clean mapping), **approximate** (conceptual equivalent with changed semantics), or **absent** (no portable ZenML equivalent -- requires redesign).
+
+## Table of Contents
+
+- [Core Primitives](#core-primitives)
+- [Template Types](#template-types)
+- [Data Passing](#data-passing)
+- [Control Flow](#control-flow)
+- [Execution Features](#execution-features)
+- [Kubernetes-Native Features](#kubernetes-native-features)
+- [Argo Events](#argo-events)
+- [Orchestrator Scheduling Support](#orchestrator-scheduling-support)
+
+## Core Primitives
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Workflow` | `@pipeline` plus a pipeline run | approximate | Same top-level role, but Argo `Workflow` is a YAML CRD + live status object; ZenML stores the definition in Python and tracks the run separately. |
+| `WorkflowTemplate` | Reusable `@pipeline` in a Python module/package | approximate | Reuse exists in both systems, but Argo stores templates in-cluster while ZenML stores them in code. |
+| `ClusterWorkflowTemplate` | Shared pipeline package, internal library, or snapshot | approximate | No cluster-global ZenML template resource. |
+| `CronWorkflow` | `Schedule(...)` on a pipeline, or schedule trigger attached to a deployment/snapshot | approximate | Argo couples schedule + workflow spec; ZenML separates scheduling from the pipeline definition. |
+| `entrypoint` | Top-level pipeline function body | direct | Both identify the root execution entry. |
+| `templateRef` / `workflowTemplateRef` | Pipeline composition, shared code import, or external snapshot/deployment trigger | approximate | Reuse exists, but child-run semantics and operational boundaries often change. |
+| Workflow-of-workflows pattern | Pipeline composition or external orchestration invoking another ZenML runnable | approximate | Treat run boundaries explicitly; plain composition may change retries and observability. |
+
+## Template Types
+
+| Argo Template Type | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `container` | `@step` with `DockerSettings`, sometimes `subprocess.run(...)` | approximate | ZenML still expects a Python-capable execution environment. |
+| `script` | `@step` body for Python, or subprocess wrapper for shell | approximate | Clean for inline Python; less clean for arbitrary shell. |
+| `dag` | Pipeline DAG built by step calls and artifact wiring | direct | Plain success-path DAGs map well; enhanced status expressions do not. |
+| `steps` | Sequential Python calls and independent branches, often in a pipeline or dynamic pipeline | approximate | Same intent, different representation; no array-of-arrays syntax. |
+| `resource` | Step that calls Kubernetes or cloud APIs explicitly | approximate | No first-class resource-template primitive exists, but the behavior can be rewritten as an explicit API step. |
+| `suspend` | External approval gate, split pipeline, or version-sensitive wait/resume feature | absent | Do not treat as a clean portable replacement; if you explore `zenml.wait(...)`, require a recent 0.94.x release, preferably `>=0.94.1`. |
+| `http` | Step using `requests` or another client SDK | approximate | Transport logic moves into Python code. |
+| `plugin` | Explicit SDK/API step, webhook call, or external service | absent | No plugin-template analogue. |
+| `containerSet` | Redesign as one step, supervisor process, or external service | absent | No multi-container same-pod primitive. |
+| `data` | Loader/transform `@step`s and typed artifacts | approximate | ZenML handles data sourcing and transformation as ordinary step logic. |
+
+## Data Passing
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Workflow parameters | Pipeline function arguments | direct | Cleanest mapping. |
+| Template input parameters | Step function arguments | direct | Cleanest mapping. |
+| `arguments.parameters` on a task/step | Step invocation kwargs | direct | The dependency edge becomes a function call. |
+| `{{workflow.parameters.foo}}` | Python variable / pipeline arg `foo` | direct | Replace string substitution with ordinary variables. |
+| Output parameter via `valueFrom.path` | Named step return value | approximate | File extraction becomes an explicit return. |
+| `outputs.result` from script/container/HTTP | Explicit step return value | approximate | ZenML has no implicit stdout/body result contract. |
+| Input/output artifacts between templates | Upstream/downstream typed artifacts | approximate | Same idea, but ZenML artifacts are typed objects in an artifact store. |
+| Artifact `path:` inside a template | Internal step implementation detail, or explicit `Path` / URI artifact | approximate | Do not assume downstream steps share the same filesystem. |
+| Artifact repository / `artifactRepositoryRef` | Artifact store + service connectors + secrets | approximate | ZenML has no per-workflow artifact repo reference. |
+| S3 / GCS / MinIO / Git / HTTP / HDFS artifact locations | Artifact store or explicit IO at pipeline edges | approximate | External URIs usually become loader/publisher steps. |
+| `globalName` for outputs | Explicit pipeline outputs, metadata, model registry, or external store | approximate | No automatic workflow-global output namespace. |
+| File-based `/tmp/...` contracts | Typed return values or explicit external storage URIs | approximate | Must not be preserved implicitly. |
+| Pre-existing external data | `ExternalArtifact` or explicit loader step | approximate | ZenML can inject external data, but via a different mechanism. |
+
+## Control Flow
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `dag.tasks[].dependencies` | Artifact wiring and, when needed, explicit `after` ordering | direct | For plain success-only dependencies. |
+| `dag.tasks[].depends` with status expressions | No direct equivalent | absent | `.Failed`, `.Errored`, `.Skipped`, `.Daemoned`, and boolean status logic require redesign. |
+| Steps template outer arrays | Sequential Python step calls | direct | The structure becomes ordinary code. |
+| Steps template inner arrays | Independent branches the orchestrator may run in parallel | approximate | Parallelism emerges from dependencies, not array syntax. |
+| `when` on parameter/value expressions | `if` / `for` in `@pipeline(dynamic=True)` | approximate | Works for value-based control flow. |
+| `when` on task status | No direct equivalent | absent | Failure-state branching is not a ZenML primitive. |
+| `withItems` | Dynamic pipeline map or manual loop | approximate | Intent survives, but semantics and parallelism limits differ. |
+| `withParam` | Upstream step returns a real list artifact, then dynamic fanout | approximate | JSON-string expansion becomes typed list expansion. |
+| `withSequence` | Python `range(...)` in a dynamic pipeline | direct | Clean intent match. |
+| `continueOn` | Typed result objects and careful use of pipeline execution modes | approximate | No per-edge direct equivalent. |
+| `onExit` | Hooks, idempotent cleanup, external cleanup, or in-step `try/finally` | approximate | Not a guaranteed workflow-wide finalizer. |
+| Lifecycle hooks | Step hooks / notifications | approximate | ZenML hooks are simpler and not expression-driven. |
+
+## Execution Features
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `retryStrategy.limit` + backoff | `StepRetryConfig(max_retries, delay, backoff)` | approximate | Similar shape, smaller policy surface. |
+| `retryPolicy` (`OnFailure`, `OnError`, etc.) | Exception discipline inside step code | approximate | No first-class retry policy taxonomy. |
+| Retry expression using `lastRetry.*` | No direct equivalent | absent | Must be rewritten in code or external control logic. |
+| Workflow `activeDeadlineSeconds` | Orchestrator/job timeout settings, usually platform-specific | approximate | No portable global workflow timeout primitive. |
+| Template timeout / deadline | In-code timeout or orchestrator-specific setting | approximate | Not a portable step-level primitive. |
+| DAG `failFast` | Closest analogue is pipeline execution mode such as `STOP_ON_FAILURE` | approximate | Similar intent, not identical behavior. |
+| `memoize` | Step caching | approximate | Argo uses explicit keys; ZenML hashes code + inputs + other factors. |
+| `synchronization.mutexes` | External lock service or platform lock | absent | No built-in portable mutex primitive. |
+| `synchronization.semaphores` | External concurrency control | absent | No built-in portable semaphore primitive. |
+| Workflow/controller `parallelism` limits | Orchestrator/platform settings | approximate | Usually moves out of pipeline code. |
+
+## Kubernetes-Native Features
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Container `resources.requests/limits` | `ResourceSettings(...)` | approximate | Portable request API, but enforcement varies by orchestrator. |
+| GPU resource scheduling | `ResourceSettings(gpu_count=...)` plus orchestrator settings | approximate | Placement details stay platform-specific. |
+| `nodeSelector` | Kubernetes-aware orchestrator pod settings | approximate | Available only on supporting orchestrators. |
+| `tolerations` | Kubernetes-aware orchestrator pod settings | approximate | Orchestrator-specific, not portable pipeline logic. |
+| `affinity` | Orchestrator pod settings | approximate | Same portability warning. |
+| `schedulerName` | Kubernetes orchestrator pod settings | approximate | Kubernetes-only. |
+| `serviceAccountName` / RBAC | Stack auth, service connectors, orchestrator settings | approximate | Auth moves into stack configuration more than pipeline code. |
+| Pod secrets / env / imagePullSecrets | ZenML secrets store + connectors + pod settings | approximate | Possible, but modeled differently. |
+| `volumes` | No portable equivalent across isolated steps | absent | Prefer artifacts, external durable storage, or collapsing logic into one step. |
+| `volumeClaimTemplates` | No direct equivalent | absent | Shared-workspace patterns must be redesigned. |
+| `emptyDir` shared scratch space | No cross-step equivalent | absent | Only same-container or same-step redesign preserves it. |
+| `sidecars` | No portable equivalent | absent | Same-pod concurrent helper containers do not map cleanly. |
+| `initContainers` | Kubernetes orchestrator pod settings only | approximate | Possible only as Kubernetes-specific pod customization. |
+| Daemon containers | No equivalent | absent | Background same-scope pod semantics are missing. |
+| `podSpecPatch`, labels, env, additional pod args | Kubernetes orchestrator `pod_settings` | approximate | Powerful, but explicitly non-portable. |
+
+## Argo Events
+
+| Argo Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `EventSource` | External webhook / broker / queue feeding ZenML | absent | No native ZenML EventSource object is documented in current public docs; legacy event-source APIs were removed in 0.94.0. |
+| `Sensor` | External automation glue or trigger-management flow | absent | No documented native dependency manager analogue for event conditions. |
+| `Trigger` | Pro trigger concept for automated execution, or deployment / snapshot / pipeline run invocation | approximate | ZenML introduced a Pro `Trigger` concept in 0.94.0, but the first documented trigger type is schedules, not an Argo-Events-style graph. |
+| Event dependency conditions | External event logic | absent | No Argo-style boolean event dependency graph is documented publicly. |
+| Webhook event source | External webhook handler calling a ZenML endpoint | approximate | Integration pattern, not a first-class ZenML event source. |
+| Schedule event source | ZenML `Schedule` or Pro schedule trigger | approximate | Time-based triggering is documented and supported when the orchestrator supports it. |
+| EventBus / CloudEvents fabric | External platform concern | absent | No direct ZenML equivalent documented publicly. |
+
+## Orchestrator Scheduling Support
+
+Scheduling is orchestrator-dependent in ZenML. Keep this table nearby whenever migrating a `CronWorkflow`:
+
+| Orchestrator | Scheduling Support | Supported Schedule Types | Native Schedule Management |
+|---|:---:|---|:---:|
+| AirflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| AzureMLOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| DatabricksOrchestrator | ✅ | Cron only | ⛔️ |
+| HyperAIOrchestrator | ✅ | Cron, One-time | ⛔️ |
+| KubeflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| KubernetesOrchestrator | ✅ | Cron only | ✅ |
+| LocalOrchestrator | ⛔️ | N/A | N/A |
+| LocalDockerOrchestrator | ⛔️ | N/A | N/A |
+| SagemakerOrchestrator | ✅ | Cron, Interval, One-time | ⛔️ |
+| SkypilotAWSOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotAzureOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotGCPOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotLambdaOrchestrator | ⛔️ | N/A | N/A |
+| TektonOrchestrator | ⛔️ | N/A | N/A |
+| VertexOrchestrator | ✅ | Cron only | ⛔️ |
+
+Always verify the target orchestrator before promising a clean schedule migration.

--- a/skills/zenml-argo-migration/skills/argo-migration/references/gaps-and-flags.md
+++ b/skills/zenml-argo-migration/skills/argo-migration/references/gaps-and-flags.md
@@ -1,0 +1,329 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the patterns that are most dangerous to silently approximate during migration -- the places where Argo Workflows and ZenML behave fundamentally differently, and where a naive translation changes the pipeline's actual behavior.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Argo Template Classification Guide](#argo-template-classification-guide)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Argo Equivalent](#zenml-features-with-no-argo-equivalent)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### Shared volumes between steps (PVC / `emptyDir`)
+
+**What Argo does**: multiple steps mount the same volume and exchange files directly.
+
+**Why it matters**: the filesystem becomes part of the workflow API. Downstream logic may depend on file layout, mutation order, or large shared intermediates.
+
+**ZenML gap**: ZenML steps are isolated by default. Cross-step local filesystem sharing is not a portable contract.
+
+**Redesign approaches**:
+- return typed artifacts or explicit `Path` artifacts
+- move state to object storage / database / artifact store
+- collapse tightly coupled logic into one step when the shared filesystem is essential
+
+### `containerSet` / multi-container pod
+
+**What Argo does**: multiple containers run in one pod with shared host, network, and filesystem semantics.
+
+**Why it matters**: low-latency sharing and same-pod lifecycle behavior are often part of correctness, not just convenience.
+
+**ZenML gap**: no first-class multi-container same-pod primitive.
+
+**Redesign approaches**:
+- collapse the behavior into one step
+- manage the multi-container pod from a Kubernetes-coupled step
+- keep that subsystem outside ZenML if same-pod semantics are core
+
+### Status-based branching (`depends: "A.Failed"`, `.Errored`, `.Skipped`, ...)
+
+**What Argo does**: controller-level control flow branches on task result states.
+
+**Why it matters**: failure handling, cleanup, and alerting semantics are explicit and often business-critical.
+
+**ZenML gap**: ZenML does not have a portable "run this step iff an upstream step failed" primitive.
+
+**Redesign approaches**:
+- model error-as-data explicitly (for example `{ok: bool, result: ...}`)
+- branch in dynamic pipelines on explicit status values
+- move notifications into hooks
+- split recovery / monitoring / cleanup into separate flows
+
+### `onExit`
+
+**What Argo does**: guaranteed finalizer template that runs when the workflow ends, regardless of success or failure.
+
+**Why it matters**: cleanup, notification, and chaining logic often depends on that always-run guarantee.
+
+**ZenML gap**: hooks and execution modes are not equivalent to a workflow-level finalizer.
+
+**Redesign approaches**:
+- use idempotent cleanup steps that do not depend on failed outputs
+- use `try/finally` inside the owning step where appropriate
+- combine hooks, external run monitoring, and careful execution mode choices
+
+### Arbitrary non-Python container steps
+
+**What Argo does**: any container image and command can be the execution primitive.
+
+**Why it matters**: the image itself may carry the entire toolchain and reproducibility story.
+
+**ZenML gap**: ZenML is Python-first; remote execution still expects a Python-capable runtime.
+
+**Redesign approaches**:
+- rebuild the tool as Python-callable logic
+- create a custom Python-capable base image for ZenML
+- keep those nodes outside ZenML if the workflow is fundamentally non-Python
+
+### File-path parameter passing (`valueFrom.path`, `/tmp` contracts)
+
+**What Argo does**: output parameters are often derived from file content; local paths are part of the data contract.
+
+**Why it matters**: hidden path-based contracts break easily when steps become isolated.
+
+**ZenML gap**: ZenML prefers typed returns; filesystem paths are not stable step interfaces.
+
+**Redesign approaches**:
+- replace with explicit return values
+- return a `Path` artifact when a file contract is genuinely required
+- use custom materializers where the contract is file- or archive-shaped
+
+### Synchronization (mutexes / semaphores)
+
+**What Argo does**: controller-managed locks and concurrency controls protect scarce external resources.
+
+**Why it matters**: removing them can create race conditions or overload shared systems.
+
+**ZenML gap**: no general built-in lock primitive.
+
+**Redesign approaches**:
+- external lock service (Redis / DB / object-store lock)
+- scheduler-level concurrency controls where available
+- explicit queueing or batching outside the pipeline
+
+### Sidecars and init containers
+
+**What Argo does**: helper containers run alongside the main workload or prepare the pod before the workload starts.
+
+**Why it matters**: some workflows depend on proxies, local services, or bootstrapping side effects.
+
+**ZenML gap**: not portable; Kubernetes-specific pod customisation may help, but it is not a first-class portable workflow concept.
+
+**Redesign approaches**:
+- replace the sidecar dependency with a managed external service
+- use Kubernetes-specific orchestrator settings when Kubernetes coupling is acceptable
+- bake init-container setup into the image or step preamble when possible
+
+### Dynamic fan-out (`withItems`, `withParam`)
+
+**What Argo does**: controller expands tasks dynamically from literals or JSON strings.
+
+**Why it matters**: cardinality, parallelism, aggregation, and failure behavior are part of the operational contract.
+
+**ZenML gap**: ZenML dynamic fanout uses a different runtime model.
+
+**Redesign approaches**:
+- use dynamic pipelines with real list artifacts and `.map()`
+- validate orchestrator support and failure semantics
+- redesign very large or event-shaped fanout into separate runs if needed
+
+### Argo Events graph
+
+**What Argo does**: EventSource + Sensor + Trigger + dependency logic form a native eventing graph.
+
+**Why it matters**: the event system is part of the platform architecture, not just an optional trigger.
+
+**ZenML gap**: current ZenML docs do not describe an Argo-Events-style native graph. ZenML 0.94.0 introduced a Pro `Trigger` concept, but the first documented trigger type is schedules, and the same 0.94.0 changelog says legacy triggers / actions / event-source APIs were removed.
+
+**Redesign approaches**:
+- external event system invokes a ZenML deployment / pipeline run / snapshot trigger
+- keep event routing and dependency logic explicit in the surrounding platform
+- treat any ZenML trigger usage as a narrow automation target, not as a drop-in EventSource/Sensor replacement
+
+---
+
+## Argo Template Classification Guide
+
+Classify each template before migrating it. This is the Argo analogue of the Databricks notebook guide: it tells you how safe the translation really is.
+
+### Detection checklist
+
+| Pattern | Detection | Risk Level |
+|---|---|---|
+| Simple `script` template with inline Python | Python logic, clear inputs, clear outputs | LOW -- usually maps to a `@step` |
+| Simple `container` template with Python-friendly runtime | CLI or Python code, minimal pod coupling | LOW / MEDIUM -- may map to a `@step` with `DockerSettings` |
+| `dag` template using plain success dependencies | `dependencies` only, no status expressions | LOW -- orchestration shape usually maps well |
+| `steps` template with simple sequential/parallel groups | Outer sequential arrays, inner parallel arrays | MEDIUM -- structure maps, parallel semantics vary |
+| Output parameters from files or `outputs.result` | `valueFrom.path`, stdout/body capture | MEDIUM -- convert to typed returns carefully |
+| Artifact passing via file paths | input/output artifacts with explicit paths | MEDIUM -- often becomes `Path` or typed artifacts |
+| `resource` or `http` template | API / infrastructure operation wrapped in a template | MEDIUM -- move explicit SDK/client logic into a step |
+| `withItems` / `withParam` fanout | loop expansion at runtime | MEDIUM / HIGH -- validate dynamic pipeline semantics |
+| `CronWorkflow` | workflow schedule bundled with workflow spec | MEDIUM -- scheduling support is orchestrator-dependent |
+| `suspend` | approval or pause node | HIGH -- control-boundary redesign required; only consider `zenml.wait(...)` on recent 0.94.x releases, preferably `>=0.94.1` |
+| `containerSet` | multi-container pod | HIGH -- same-pod semantics are core |
+| Shared volumes / PVCs / `emptyDir` | cross-step filesystem sharing | HIGH -- redesign hotspot |
+| Enhanced `depends` logic | task-status branching | HIGH -- no direct equivalent |
+| Sidecars / init containers / daemon containers | extra pod topology | HIGH -- portable translation is not available |
+| EventSource / Sensor / Argo Events | event graph outside core workflow | HIGH -- integration architecture decision required |
+
+### Classification outcomes
+
+**Auto-refactorable** (low risk):
+- simple `script` template with Python logic
+- simple `container` template where a Python-capable ZenML image is reasonable
+- plain `dag` or `steps` orchestration using ordinary success-path dependencies
+- parameter-only data flow and clear typed return values
+
+**Semi-automatic** (medium risk):
+- artifact passing where a file or `Path` contract must be kept explicit
+- `resource` / `http` templates
+- `withItems`, `withParam`, `withSequence`
+- `CronWorkflow`
+- pod resource requests and placement settings that can move into orchestrator config
+
+**Manual redesign required** (high risk):
+- enhanced `depends` status logic
+- `containerSet`
+- sidecars / same-pod helper services
+- shared PVC / mutable filesystem contracts between steps
+- `onExit` when correctness depends on always-run behavior
+- synchronization locks
+- Argo Events graphs
+
+---
+
+## Behavioral Differences
+
+### Declarative YAML vs imperative Python
+
+| Aspect | Argo Workflows | ZenML Pipelines |
+|---|---|---|
+| Authoring format | YAML CRDs | Python functions |
+| Composition mechanism | Template refs + DAG/steps spec + variable substitution | Function composition and artifact wiring |
+| Migration effect | You are porting manifests | You are rewriting the execution program into code |
+
+### File-based artifacts vs typed artifacts
+
+| Aspect | Argo | ZenML |
+|---|---|---|
+| Data contract | Files, paths, artifact repos | Typed artifacts in an artifact store |
+| Output parameters | Often extracted from files / stdout | Explicit return values |
+| Migration effect | Path contracts are normal | Typed values are normal; path contracts must be explicit |
+
+### Kubernetes-native vs stack-abstracted
+
+| Aspect | Argo | ZenML |
+|---|---|---|
+| Execution assumption | Kubernetes is the substrate | Orchestrator is a pluggable stack component |
+| Pod-level controls | First-class workflow knobs | Mostly orchestrator-specific settings |
+| Migration effect | Kubernetes details sit inside workflow authoring | Separate business logic from infrastructure logic |
+
+### Volume sharing vs container isolation
+
+| Aspect | Argo | ZenML |
+|---|---|---|
+| Shared filesystems | Common pattern | Not a portable step boundary |
+| Same-pod helpers | Sidecars / containerSet / init containers | No portable same-pod equivalent |
+| Migration effect | File mutation and pod topology can be part of correctness | Prefer artifacts, explicit stores, or one-step redesign |
+
+### Parameter substitution vs function arguments
+
+| Aspect | Argo | ZenML |
+|---|---|---|
+| Passing values | `{{...}}` substitution and workflow variables | Typed function args and artifact inputs |
+| Produced upstream values | Often still called "parameters" | They become artifacts |
+| Migration effect | String-substituted wiring | Explicit type-aware data flow |
+
+### Exit handlers vs hooks and execution modes
+
+| Aspect | Argo | ZenML |
+|---|---|---|
+| Always-run finalization | `onExit` | No direct run-level `finally` primitive |
+| Notifications | Finalizer templates and hooks | Step hooks and external monitoring |
+| Migration effect | Cleanup guarantees are stronger in Argo | Finalization must be redesigned explicitly |
+
+---
+
+## Migration Decision Tree
+
+Use this procedure for every Argo component. The goal is to force an explicit decision instead of a hopeful translation.
+
+```text
+1. Identify the object kind first.
+   - Workflow / WorkflowTemplate / ClusterWorkflowTemplate -> execution logic track
+   - CronWorkflow -> split scheduling from execution immediately
+   - EventSource / Sensor -> event-integration track, not ordinary workflow translation
+
+2. Identify the template type.
+   - container / script / data -> step candidate
+   - dag / steps -> orchestration structure to rebuild in Python
+   - resource / http / plugin -> explicit SDK/API step
+   - suspend / containerSet / sidecars / status-driven control flow -> redesign-first
+
+3. Separate direct inputs from produced data.
+   - workflow parameters and literal arguments -> pipeline / step parameters
+   - outputs.parameters / outputs.result / outputs.artifacts -> artifacts, not params
+
+4. Ask whether the contract is value-based or path-based.
+   - if downstream needs only the value -> return a normal Python type
+   - if downstream needs a specific file / archive / URI -> model it explicitly
+
+5. Inspect control flow for anything beyond success-path dependencies.
+   - plain dependencies -> usually safe
+   - status-based depends / continueOn / onExit / lifecycle hooks -> classify before coding
+
+6. Inspect loop shape.
+   - fixed numeric sequence -> Python range(...)
+   - literal list or upstream-produced list -> real list artifact + dynamic fanout
+   - controller-side status-dependent expansion -> approximate or absent, document the shift
+
+7. Inspect runtime coupling.
+   - shared volumes / same-pod services / sidecars / init containers / locks -> redesign territory
+
+8. Move Kubernetes-specific configuration out of business logic.
+   - ResourceSettings often survive
+   - pod placement, service accounts, tolerations, and init containers belong in orchestrator config
+
+9. Classify the mapping explicitly.
+   - Direct = dependency and data semantics stay intact
+   - Approximate = intent survives but semantics change
+   - Absent = feature depends on controller / pod / event-graph behavior ZenML does not model
+
+10. Only then write the ZenML code.
+    - test value correctness
+    - test dependency correctness
+    - test operational correctness
+```
+
+Compact rule of thumb:
+
+```text
+If the Argo feature is about values and success-path dependencies, it probably maps.
+If it is about filesystems, pod topology, controller policy, or event graphs, it probably needs redesign.
+```
+
+---
+
+## ZenML Features with No Argo Equivalent
+
+These are capabilities the user gains after migration. Mention the relevant ones in the "What You Get for Free" section of the migration report.
+
+| ZenML Feature | Description |
+|---|---|
+| **Typed artifacts with materializers** | Data contracts become explicit Python types instead of file-path conventions. |
+| **Artifact versioning and lineage** | Artifacts are versioned and traceable across runs. |
+| **Step caching** | Skip re-execution when code and inputs have not changed. |
+| **Stack abstraction** | The same pipeline code can move across local, Kubernetes, Kubeflow, Vertex, SageMaker, AzureML, and more. |
+| **ExternalArtifact** | First-class injection of pre-existing external data into a typed pipeline graph. |
+| **Model Control Plane** | Track model versions, stages, and lineage after ML pipeline migration. |
+| **Service connectors** | Unified cloud auth and reusable infrastructure access patterns. |
+| **ZenML secrets store** | Workflow-facing secret management that is more centralized at the pipeline platform layer. |
+| **YAML run configuration templates** | Multi-environment config layered over one Python codebase. |
+| **Snapshots / deployments distinction** | Cleaner separation between batch reruns and long-running serving/inference systems. |

--- a/skills/zenml-azureml-migration/plugin.json
+++ b/skills/zenml-azureml-migration/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "zenml-azureml-migration",
+  "version": "1.0.0",
+  "description": "Migrate Azure Machine Learning SDK v2 pipelines to idiomatic ZenML pipelines with concept mapping, Azure-aware compute translation, code patterns, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "azureml",
+    "azure-machine-learning",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration",
+    "mldesigner"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-azureml-migration/skills/azureml-migration/SKILL.md
+++ b/skills/zenml-azureml-migration/skills/azureml-migration/SKILL.md
@@ -1,0 +1,447 @@
+---
+name: azureml-to-zenml-migration
+description: >-
+  Migrate Azure Machine Learning SDK v2 pipelines, components, environments,
+  and schedules to idiomatic ZenML pipelines. Handles concept mapping
+  (`@pipeline` -> `@pipeline`, `@command_component` -> `@step`,
+  `Environment(...)` -> `DockerSettings(...)`,
+  AzureML compute -> `AzureMLOrchestratorSettings`), code translation,
+  Azure-aware "keep AzureML" migration paths, and flags unsupported or unsafe
+  patterns (sweep jobs, parallel jobs, managed endpoints, AzureML Registry,
+  Responsible AI dashboard, and unverified control-flow helpers like
+  `if_else` and `do_while`) for human review. Use this skill whenever the user
+  mentions AzureML migration, Azure Machine Learning SDK v2 migration,
+  converting AzureML pipelines or components, porting workflows from AzureML,
+  replacing AzureML authoring with ZenML, or asks how AzureML concepts map to
+  ZenML -- even if they don't explicitly say "migrate". Also use when they
+  paste AzureML SDK v2 code, `mldesigner` components, YAML components,
+  `load_component()` usage, MLTable/data asset definitions, or AzureML
+  scheduling/deployment code and ask to make it work with ZenML. If the user
+  just asks a quick conceptual question ("what's the ZenML equivalent of an
+  AzureML Environment?"), answer it directly from the concept map -- no need
+  to run the full migration workflow.
+---
+
+# Migrate AzureML SDK v2 Pipelines to ZenML
+
+This skill translates **Azure Machine Learning SDK v2** pipelines into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing AzureML pipeline code and assets, classifying each pattern, choosing when to keep AzureML as the execution plane, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project.
+
+> SDK v1 is out of scope. If the user is still on AzureML SDK v1, first normalize the workflow to SDK v2 concepts, then migrate the SDK v2 version to ZenML.
+
+## How migration works at a high level
+
+AzureML and ZenML solve overlapping problems, but they organize the world differently:
+
+- **AzureML authoring is asset-centric**: components, environments, data assets, model assets, and compute are all separate first-class objects.
+- **ZenML authoring is Python-workflow-centric**: the main surface is `@step` + `@pipeline`, with containerization handled by `DockerSettings` and infrastructure handled by the active stack and orchestrator settings.
+
+That means migration is not just a syntax rewrite. Some AzureML ideas translate directly, some translate approximately, and some should stay Azure-native or be redesigned.
+
+### The "keep AzureML" migration path
+
+This is not always a story of leaving Azure. Often the best migration is:
+
+1. Keep **AzureML as the execution plane**
+2. Move **workflow authoring** into ZenML
+3. Preserve Azure compute, AzureML Studio job inspection, workspace security context, and Azure scheduling where it still makes sense
+
+In that setup, ZenML authors the workflow, and the AzureML orchestrator submits AzureML jobs under the hood.
+
+### If you choose the "keep AzureML" path, confirm prerequisites first
+
+Before promising a keep-Azure migration, verify that the target ZenML stack can actually run on the AzureML orchestrator. The official ZenML AzureML orchestrator docs call out these prerequisites:
+
+- the ZenML `azure` integration installed
+- Docker running locally **or** a remote image builder in the stack
+- a **remote artifact store**
+- a **remote container registry**
+- an Azure resource group with an **AzureML workspace**
+- Azure authentication configured for the orchestrator
+
+For authentication, default authentication can be fine during development, but **service principal authentication is the recommended production path**. If the user wants to keep AzureML execution, ask early whether these stack prerequisites already exist. If they do not, say so plainly in the migration plan instead of making it sound like the code translation alone is sufficient.
+
+### The three mapping types
+
+Every AzureML concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in the migration report |
+| **Absent** | No ZenML equivalent | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the AzureML Workflow
+
+Ask the user for the AzureML assets that actually define the workflow. They may provide:
+
+- Python SDK v2 pipeline code (`@pipeline`, `@command_component`, `PipelineJob`)
+- `mldesigner` components
+- YAML component definitions used with `load_component()`
+- environment definitions (`Environment(...)`, curated environment names, Docker build contexts)
+- compute configuration (serverless, compute instances, compute clusters, node-level overrides)
+- data/model asset references (`uri_file`, `uri_folder`, `mltable`, model assets)
+- schedule definitions (`JobSchedule`, cron, recurrence)
+- deployment code (managed online endpoints, batch endpoints)
+
+Read everything thoroughly before doing anything else. For each workflow, identify:
+
+1. **Pipeline graph** -- Which nodes exist, and how are outputs wired into downstream inputs?
+2. **Component types** -- Are components Python-defined, YAML-defined, registered, or pipeline components?
+3. **Environment usage** -- Does each component own its own environment asset? Are there custom images, Conda files, or Docker build contexts?
+4. **Compute bindings** -- Is compute set at the pipeline level, node level, or both? Are there heterogeneous per-node requirements?
+5. **Data and model asset semantics** -- Are asset IDs and versions part of the business logic, or are they just storage details?
+6. **MLTable usage** -- Is MLTable just a convenient input type, or does the workflow depend on MLTable-specific semantics?
+7. **Advanced job types** -- Any sweep jobs, parallel jobs, Spark jobs, AutoML jobs, import/data transfer jobs?
+8. **Scheduling** -- Cron or recurrence? Is the user expecting ZenML to fully manage schedule lifecycle after creation?
+9. **Deployment flows** -- Does the workflow register models or deploy managed online/batch endpoints?
+10. **Platform dependencies** -- Registry sharing, Responsible AI dashboard, Designer, workspace-specific networking, or other Azure-only features?
+11. **Target stack prerequisites** -- If the plan is to keep AzureML execution, does the user already have the Azure integration, remote artifact store, remote container registry, AzureML workspace, and authentication/service connector setup needed by the AzureML orchestrator?
+12. **Control flow helpers** -- Any use of `if_else`, `do_while`, `parallel_for`, or `set_pipeline_controller_configurations`?
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it as direct / approximate / absent using [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+**Direct translations (translate automatically):**
+- `@pipeline` -> `@pipeline`
+- `@command_component` -> `@step`
+- Pipeline parameters/defaults -> typed Python parameters/defaults
+- Primitive AzureML inputs -> normal Python parameters
+- AzureML serverless / compute instance / compute cluster -> `AzureMLOrchestratorSettings(mode=...)`
+- Azure cron / recurrence schedules -> ZenML `Schedule(...)` **when the AzureML orchestrator is the target**
+- MLflow tracking inside AzureML -> MLflow usage inside ZenML steps
+
+**Approximate translations (translate with caveats):**
+- `Environment(image=..., conda_file=...)` -> `DockerSettings(...)`
+- YAML components loaded via `load_component()` -> rewrite as Python `@step`
+- `Input` / `Output` asset types -> step parameters and return values
+- `node.compute = ...` -> step-specific runtime config, step operator settings, or separate pipelines
+- MLTable/data assets -> URI boundaries, artifacts, or explicit Azure asset IDs passed through as strings
+- Pipeline components/sub-pipelines -> helper pipeline functions
+- Model registration -> ZenML model object plus optional Azure registration step
+- AutoML -> call Azure AutoML from a ZenML step, or replace with explicit training/HPO
+
+**Absent / needs redesign (flag for human review):**
+- Sweep jobs as a native ZenML primitive
+- Parallel jobs as a native ZenML primitive
+- Managed online endpoints / batch endpoints as native ZenML deployment primitives
+- AzureML Registry and registered component registry semantics
+- Responsible AI dashboard
+- Designer
+- Cross-workspace asset sharing semantics
+- `if_else`, `do_while`, `parallel_for`, `set_pipeline_controller_configurations` as safe auto-translations
+
+#### Present the migration plan
+
+Before writing any code, present a summary to the user:
+
+> "Here's what I found in your AzureML workflow:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with caveats): [list]
+> - **Needs redesign / stays Azure-native**: [list with brief explanation]
+>
+> The key architectural choice is whether to keep AzureML as the execution plane via the AzureML orchestrator, or to move execution to another ZenML stack. Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain each one concretely:
+
+- what the AzureML code does today
+- why ZenML cannot reproduce it literally
+- whether the right answer is **keep Azure-native**, **call the Azure SDK from a step**, or **redesign the workflow**
+
+### Phase 3: Generate ZenML Code
+
+Translate the AzureML workflow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── train.py
+│   └── evaluate.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Custom materializers (if needed)
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+Key rules:
+
+- One step per file in `steps/`
+- Separate pipeline definition from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` uses `requires-python = ">=3.12"`
+- Always generate both `configs/dev.yaml` and `configs/prod.yaml`
+- Always generate a `README.md` explaining what stayed Azure-native and what requires manual attention
+- If helpful, include a small ASCII DAG diagram in the pipeline module docstring
+- Run `zenml init` at the project root
+
+#### Translation patterns
+
+See [references/code-patterns.md](references/code-patterns.md) for detailed side-by-side examples.
+
+The core translation rule is:
+
+1. Move AzureML component logic into a typed `@step`
+2. Move environment definitions into `DockerSettings`
+3. Move compute choices into orchestrator settings (or explicit runtime config)
+4. Replace asset edge wiring with step return values and step inputs
+
+```python
+# AzureML
+@command_component(name="train_model")
+def train_component(input_data: Input(type="uri_folder"), epochs: int = 10):
+    ...
+
+# ZenML
+@step
+def train_step(input_data_uri: str, epochs: int = 10) -> str:
+    ...
+```
+
+#### Environment translation rule
+
+AzureML environments are not first-class ZenML assets. Translate them into Docker/container settings:
+
+```python
+from zenml.config import DockerSettings
+
+docker_settings = DockerSettings(
+    parent_image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+    requirements=["mlflow", "scikit-learn"],
+)
+```
+
+If the AzureML environment used a custom Docker build context, preserve that with `dockerfile=...` and `build_context_root=...`.
+
+#### Compute translation rule
+
+If the user wants to **keep AzureML execution**, prefer `AzureMLOrchestratorSettings`:
+
+```python
+from zenml.integrations.azure.flavors import AzureMLOrchestratorSettings
+
+cluster = AzureMLOrchestratorSettings(
+    mode="compute-cluster",
+    compute_name="gpu-cluster",
+    size="Standard_NC6s_v3",
+    min_instances=0,
+    max_instances=4,
+)
+```
+
+Use this as the default migration path whenever preserving Azure compute behavior is important.
+
+#### Data and asset translation rule
+
+AzureML asset-typed inputs/outputs (`uri_file`, `uri_folder`, `mltable`, model assets) do **not** map to first-class ZenML asset descriptors. Decide case by case:
+
+- If the asset identity matters, keep the Azure asset ID/URI explicit
+- If only the data matters, translate to artifacts or loaded Python objects
+- If the workflow crosses Azure-native boundaries, keep the boundary explicit in the migrated code
+
+#### Scheduling rule
+
+ZenML can create AzureML cron/interval schedules when using the AzureML orchestrator, but ZenML does **not** fully manage schedule lifecycle on Azure afterward. Always call this out in the migration report.
+
+#### Handling approximate translations
+
+When translating approximate patterns, add concise inline comments describing the changed behavior:
+
+```python
+@step(settings={"docker": docker_settings})
+def train_step(input_data_uri: str) -> str:
+    # Migration note: the original AzureML component used an Environment asset.
+    # This step uses DockerSettings instead, so environment reuse/versioning now
+    # lives in code and image configuration rather than in Azure asset registry state.
+    ...
+```
+
+#### Handling absent patterns
+
+For patterns with no safe ZenML equivalent:
+
+1. Add a `# TODO(migration):` comment in the generated code
+2. Include the item in the migration report
+3. State clearly whether the user should:
+   - keep the Azure feature external,
+   - call the Azure SDK from a ZenML step, or
+   - redesign the workflow
+
+```python
+# TODO(migration): UNSUPPORTED -- AzureML parallel job semantics are not a safe
+# 1:1 ZenML translation. Keep the Azure parallel job native, or redesign this
+# workload as a dynamic ZenML pipeline only after validating data partitioning,
+# concurrency, and retry semantics.
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root:
+
+```markdown
+# Migration Report: [AzureML Workflow] -> [ZenML Pipeline]
+
+## Summary
+- **Source**: AzureML SDK v2 workflow `[name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Components migrated**: X direct, Y approximate, Z flagged
+- **Execution target**: AzureML orchestrator / other ZenML stack
+
+## Direct Translations
+| AzureML Concept | ZenML Equivalent | Notes |
+|---|---|---|
+
+## Approximate Translations
+| AzureML Concept | ZenML Equivalent | What Changed |
+|---|---|---|
+
+## Flagged for Review
+| AzureML Pattern | Severity | Issue | Recommended Path |
+|---|---|---|---|
+
+## Environment Translation Summary
+| AzureML Environment | ZenML DockerSettings | Notes |
+|---|---|---|
+
+## Compute Mapping
+| AzureML Compute | ZenML Equivalent | Notes |
+|---|---|---|
+
+## Scheduling
+- Original schedule
+- Migrated schedule
+- Lifecycle caveat for AzureML-managed schedules
+
+## Limitations and Key Differences
+
+## What's NOT Migrated
+
+## What You Get for Free After Migration
+
+## Recommended Next Steps
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a "Recommended Next Steps" section in the report and communicate it to the user.
+
+#### 1. Run `zenml-quick-wins`
+
+Always suggest this first:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, and other production features to your pipeline."
+
+#### 2. Link the user to the right ZenML docs
+
+For flagged patterns, include targeted docs:
+
+- Scheduling: `https://docs.zenml.io/how-to/steps-pipelines/schedule-a-pipeline`
+- Orchestrators: `https://docs.zenml.io/stacks/stack-components/orchestrators`
+- AzureML orchestrator: `https://docs.zenml.io/stacks/stack-components/orchestrators/azureml`
+- Dynamic pipelines: `https://docs.zenml.io/how-to/steps-pipelines/dynamic-pipelines`
+- Containerization: `https://docs.zenml.io/how-to/containerization/containerization`
+- Secrets management: `https://docs.zenml.io/how-to/project-setup-and-management/secret-management`
+- Auth / service connectors: `https://docs.zenml.io/how-to/infrastructure-deployment/auth-management`
+- Models / MCP: `https://docs.zenml.io/how-to/model-management-and-deployment`
+
+#### 3. Suggest the ZenML docs MCP server
+
+> "For easier access to ZenML documentation while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Offer community support for genuine gaps
+
+When there are multiple HIGH-severity flags, offer to draft a Slack message for `zenml.io/slack` summarizing:
+
+- what AzureML workflow is being migrated
+- which patterns had no safe ZenML equivalent
+- what workaround or redesign was attempted
+- what answer the user needs from the ZenML team
+
+#### 5. Offer GitHub issue creation for real product gaps
+
+If the migration reveals a genuine feature gap in ZenML, offer to open an issue on `zenml-io/zenml`.
+
+#### 6. Suggest `/simplify`
+
+After code generation, suggest running `/simplify` to reduce migration-only comments and clean up redundant patterns.
+
+#### 7. Use `zenml-pipeline-authoring` for deeper customization
+
+Recommend `zenml-pipeline-authoring` when the user needs:
+
+- advanced Docker settings
+- YAML-driven environments
+- custom materializers
+- deployment workflows
+- more complex stack-specific runtime configuration
+
+## Important Behavioral Differences to Communicate
+
+These are the places where users are most likely to get surprised after migration.
+
+### Asset model vs code model
+
+AzureML treats components, environments, and many data/model artifacts as first-class registered assets. ZenML treats the main reusable unit as Python code plus build/runtime configuration. This changes how reuse, versioning, and governance are expressed.
+
+### Environment management
+
+AzureML `Environment` objects become `DockerSettings`. The operational goal is similar, but the management surface is different:
+
+- less Azure-native registry semantics
+- more code-local, container-oriented configuration
+
+### Compute management
+
+AzureML pipeline DSL allows very explicit node-level compute choices. ZenML can preserve many Azure compute settings with the AzureML orchestrator, but strongly heterogeneous per-node compute often needs a design decision instead of a literal rewrite.
+
+### Data handling
+
+AzureML uses typed asset descriptors like `uri_folder` and `mltable`. ZenML uses Python parameters, artifacts, and materializers. Similar intent, different model.
+
+### Schedule lifecycle
+
+ZenML can create AzureML schedules, but it does not fully manage their lifecycle after creation on AzureML. Updating or deleting those schedules may remain a manual Azure task.
+
+### Control flow
+
+Treat `if_else`, `do_while`, `parallel_for`, and `set_pipeline_controller_configurations` as unsafe for automatic translation unless the user explicitly wants a redesign and accepts manual review.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Converting AzureML assets into ZenML names without changing the architecture | Keeps Azure mental model but loses correctness | Rewrite around `@step`, `@pipeline`, artifacts, and orchestrator settings |
+| Treating every AzureML Environment as a reusable ZenML asset | ZenML has no environment asset registry primitive | Move environment intent into `DockerSettings` and document the change |
+| Silently converting sweep jobs into Python loops | Changes execution semantics, observability, and retry behavior | Keep Azure sweep native, or redesign with explicit HPO tooling |
+| Silently converting parallel jobs into `.map()` | Similar shape, different guarantees | Flag for review and redesign deliberately |
+| Pretending MLTable is a first-class ZenML type | It is not | Keep it as a URI/reference boundary or load it explicitly inside a step |
+| Dropping managed endpoint logic during migration | Changes production behavior, not just authoring | Keep endpoint deployment in Azure or call Azure SDK from a step |
+| Claiming `if_else` / `do_while` are safe 1:1 conversions | They are not verified here | Flag them and require manual review |
+| Assuming ZenML will fully manage Azure schedules after creation | It will not | Document the lifecycle caveat in the migration report |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- Full mapping tables for pipeline concepts, component types, environments, compute, data assets, scheduling, model management, and Azure platform features
+- [references/code-patterns.md](references/code-patterns.md) -- Side-by-side AzureML -> ZenML code patterns for components, environments, compute, scheduling, assets, deployment, and redesign-only patterns
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- Must-flag patterns, behavioral differences, migration decision tree, and anti-patterns
+
+### ZenML documentation
+
+For topics beyond migration (stack setup, experiment tracking, deployment, authentication), query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-azureml-migration/skills/azureml-migration/references/code-patterns.md
+++ b/skills/zenml-azureml-migration/skills/azureml-migration/references/code-patterns.md
@@ -1,0 +1,504 @@
+# AzureML SDK v2 -> ZenML Code Patterns
+
+These are side-by-side translation patterns for the most common AzureML SDK v2 migration cases. Each pattern is marked as **direct**, **approximate**, or **redesign-only** so the migration does not overclaim safety.
+
+## Table of Contents
+
+- [Simple Pipeline with `@command_component`](#simple-pipeline-with-command_component)
+- [YAML-defined Component with `load_component()`](#yaml-defined-component-with-load_component)
+- [Inputs, Outputs, and Asset Types](#inputs-outputs-and-asset-types)
+- [Custom Environments](#custom-environments)
+- [Compute Target Specification](#compute-target-specification)
+- [Sweep Jobs / HPO](#sweep-jobs--hpo)
+- [Parallel Jobs / Batch Scoring](#parallel-jobs--batch-scoring)
+- [Conditional Execution](#conditional-execution)
+- [`do_while` Loops](#do_while-loops)
+- [Sub-pipelines / Pipeline Components](#sub-pipelines--pipeline-components)
+- [Scheduling](#scheduling)
+- [Model Registration and Endpoint Deployment](#model-registration-and-endpoint-deployment)
+- [MLflow Integration](#mlflow-integration)
+- [Data Assets and Versioning](#data-assets-and-versioning)
+- [Registered Components and AzureML Registry](#registered-components-and-azureml-registry)
+- [AutoML](#automl)
+
+## Simple Pipeline with `@command_component`
+
+**Classification:** direct for the main authoring pattern, approximate for environment/compute semantics
+
+### AzureML
+
+```python
+from mldesigner import command_component, Input, Output
+from azure.ai.ml.dsl import pipeline
+
+@command_component(name="prep_data")
+def prep_data(input_data: Input(type="uri_folder"),
+              training_data: Output(type="uri_folder")):
+    ...
+
+@command_component(name="train_model")
+def train_model(input_data: Input(type="uri_folder"),
+                model_output: Output(type="mlflow_model"),
+                epochs: int = 10):
+    ...
+
+@pipeline(default_compute="cpu-cluster")
+def aml_training_pipeline(pipeline_input_data):
+    prep_node = prep_data(input_data=pipeline_input_data)
+    train_node = train_model(input_data=prep_node.outputs.training_data, epochs=20)
+    train_node.compute = "gpu-cluster"
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config import DockerSettings
+from zenml.integrations.azure.flavors import AzureMLOrchestratorSettings
+
+train_docker = DockerSettings(parent_image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04")
+gpu_cluster = AzureMLOrchestratorSettings(
+    mode="compute-cluster",
+    compute_name="gpu-cluster",
+    size="Standard_NC6s_v3",
+    min_instances=0,
+    max_instances=4,
+)
+
+@step
+def prep_step(input_data_uri: str) -> str:
+    ...
+
+@step(settings={"docker": train_docker})
+def train_step(training_data_uri: str, epochs: int = 10) -> str:
+    ...
+
+@pipeline(settings={"orchestrator": gpu_cluster})
+def zenml_training_pipeline(input_data_uri: str, epochs: int = 20) -> str:
+    prepared = prep_step(input_data_uri=input_data_uri)
+    return train_step(training_data_uri=prepared, epochs=epochs)
+```
+
+**Key differences**
+- AzureML separates component, environment, and compute. ZenML collapses those into `@step`, `DockerSettings`, and orchestrator settings.
+- `node.compute = ...` is not a literal per-node DSL property in ZenML.
+
+## YAML-defined Component with `load_component()`
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+from azure.ai.ml import load_component
+
+score_component = load_component(source="./components/score.yml")
+
+@pipeline
+def scoring_pipeline(data_input):
+    score_component(input_data=data_input)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def score_step(input_data_uri: str) -> str:
+    # Rewrite the YAML-defined interface as a normal Python step.
+    ...
+
+@pipeline
+def scoring_pipeline(data_input_uri: str) -> str:
+    return score_step(input_data_uri=data_input_uri)
+```
+
+**Migration warning**
+- ZenML has YAML configuration, but not YAML-defined reusable pipeline components as a first-class asset type.
+- Rewrite the component contract in Python rather than trying to preserve the YAML component artifact.
+
+## Inputs, Outputs, and Asset Types
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+from mldesigner import command_component, Input, Output
+
+@command_component
+def transform_data(
+    raw_data: Input(type="mltable"),
+    output_data: Output(type="uri_folder"),
+    split: float = 0.2,
+):
+    ...
+```
+
+### ZenML
+
+```python
+from pandas import DataFrame
+from zenml import step
+
+@step
+def transform_data(raw_data_uri: str, split: float = 0.2) -> tuple[DataFrame, DataFrame]:
+    # Keep the Azure asset boundary explicit if MLTable identity matters.
+    ...
+```
+
+**Key differences**
+- `mltable` is not a first-class ZenML type.
+- Decide whether to keep asset IDs/URIs explicit or load the data into Python objects.
+
+## Custom Environments
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+from azure.ai.ml.entities import Environment
+
+env = Environment(
+    image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+    conda_file="./conda.yaml",
+)
+```
+
+### ZenML
+
+```python
+from zenml.config import DockerSettings
+
+docker_settings = DockerSettings(
+    parent_image="mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04",
+    requirements=["pandas", "scikit-learn"],
+)
+```
+
+**Migration warning**
+- AzureML environment assets have registry/versioning semantics that ZenML does not replicate.
+- Preserve custom Docker build details, but do not pretend environment assets survive unchanged.
+
+## Compute Target Specification
+
+**Classification:** direct for AzureML orchestrator compute modes, approximate for per-node heterogeneity
+
+### AzureML
+
+```python
+@pipeline(default_compute="cpu-cluster")
+def training_pipeline(data):
+    train_node = train_component(input_data=data)
+    train_node.compute = "gpu-cluster"
+```
+
+### ZenML
+
+```python
+from zenml.integrations.azure.flavors import AzureMLOrchestratorSettings
+
+gpu_cluster = AzureMLOrchestratorSettings(
+    mode="compute-cluster",
+    compute_name="gpu-cluster",
+    size="Standard_NC6s_v3",
+    min_instances=0,
+    max_instances=8,
+)
+
+@pipeline(settings={"orchestrator": gpu_cluster})
+def training_pipeline(data_uri: str) -> str:
+    return train_step(data_uri)
+```
+
+**Migration warning**
+- Pipeline-wide compute is a good fit.
+- Strongly heterogeneous per-node compute usually needs separate pipelines or explicit runtime configuration.
+
+## Sweep Jobs / HPO
+
+**Classification:** redesign-only
+
+### AzureML
+
+```python
+sweep_job = train_component.sweep(
+    sampling_algorithm="random",
+    primary_metric="accuracy",
+)
+```
+
+### ZenML
+
+```python
+@step
+def run_hpo(search_space: dict[str, list[float]]) -> dict[str, float]:
+    # Use Optuna or call the Azure sweep API explicitly from here.
+    ...
+```
+
+**Migration warning**
+- ZenML has no native sweep-job primitive.
+- Either keep Azure sweep native, or redesign HPO explicitly.
+
+## Parallel Jobs / Batch Scoring
+
+**Classification:** redesign-only
+
+### AzureML
+
+```python
+from azure.ai.ml.parallel import parallel_run_function
+
+parallel_component = parallel_run_function(...)
+```
+
+### ZenML
+
+```python
+@pipeline(dynamic=True)
+def scoring_pipeline(batch_uris: list[str]) -> None:
+    # Only use this after validating semantics, concurrency, and failure behavior.
+    ...
+```
+
+**Migration warning**
+- Azure parallel jobs are not just "fan out over a list".
+- Treat this as manual-review-only unless the user explicitly accepts a redesign.
+
+## Conditional Execution
+
+**Classification:** redesign-only
+
+### AzureML
+
+```python
+# AzureML helper-based conditional flow
+if_else(...)
+```
+
+### ZenML
+
+```python
+@pipeline(dynamic=True)
+def conditional_pipeline(flag: bool) -> None:
+    # Redesign deliberately. Do not claim 1:1 translation.
+    ...
+```
+
+**Migration warning**
+- `if_else` is treated as unsafe for automatic translation in this skill.
+
+## `do_while` Loops
+
+**Classification:** redesign-only
+
+### AzureML
+
+```python
+do_while(...)
+```
+
+### ZenML
+
+```python
+@step
+def run_until_converged(initial_value: float) -> float:
+    # Keep the loop inside one step, or redesign as a dynamic pipeline.
+    ...
+```
+
+**Migration warning**
+- Treat `do_while` as manual-review-only.
+
+## Sub-pipelines / Pipeline Components
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+@pipeline
+def prep_pipeline(data):
+    ...
+
+@pipeline
+def full_pipeline(data):
+    prep = prep_pipeline(data)
+    ...
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+
+@pipeline
+def prep_pipeline(data_uri: str) -> str:
+    ...
+
+@pipeline
+def full_pipeline(data_uri: str) -> str:
+    prepared = prep_pipeline(data_uri)
+    ...
+```
+
+**Key differences**
+- Composition exists in both worlds.
+- Registered pipeline component asset semantics do not.
+
+## Scheduling
+
+**Classification:** direct with lifecycle caveat
+
+### AzureML
+
+```python
+from azure.ai.ml.entities import JobSchedule, CronTrigger
+
+schedule = JobSchedule(
+    trigger=CronTrigger(expression="*/5 * * * *"),
+    create_job=pipeline_job,
+)
+```
+
+### ZenML
+
+```python
+from datetime import datetime, timezone
+from zenml.config.schedule import Schedule
+
+cron_schedule = Schedule(cron_expression="*/5 * * * *")
+daily_interval = Schedule(
+    start_time=datetime(2026, 4, 8, 10, 15, tzinfo=timezone.utc),
+    interval_second=24 * 60 * 60,
+)
+```
+
+**Migration warning**
+- ZenML can create AzureML cron/interval schedules when using the AzureML orchestrator.
+- Updating or deleting those schedules later is not fully managed through ZenML.
+
+## Model Registration and Endpoint Deployment
+
+**Classification:** approximate for registration, redesign-only for managed endpoints
+
+### AzureML
+
+```python
+from azure.ai.ml.entities import ManagedOnlineDeployment, ManagedOnlineEndpoint
+
+endpoint = ManagedOnlineEndpoint(name="fraud-endpoint")
+deployment = ManagedOnlineDeployment(name="blue", endpoint_name=endpoint.name, model=model)
+```
+
+### ZenML
+
+```python
+@step
+def register_model_in_azure(model_uri: str) -> str:
+    # Use Azure SDK here if Azure endpoint deployment must stay part of the workflow.
+    ...
+```
+
+**Migration warning**
+- ZenML has first-class model objects, but not native Azure managed endpoint primitives.
+- Keep endpoint deployment Azure-native, or call Azure SDK explicitly from a ZenML step.
+
+## MLflow Integration
+
+**Classification:** direct
+
+### AzureML
+
+```python
+import mlflow
+
+mlflow.log_metric("accuracy", 0.93)
+```
+
+### ZenML
+
+```python
+import mlflow
+from zenml import step
+
+@step
+def evaluate_model() -> float:
+    mlflow.log_metric("accuracy", 0.93)
+    return 0.93
+```
+
+**Key differences**
+- The MLflow API usage can stay familiar.
+- The surrounding orchestration, lineage, and model management surface changes.
+
+## Data Assets and Versioning
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+from azure.ai.ml import Input
+
+data_input = Input(type="mltable", path="azureml:customer_data:12")
+```
+
+### ZenML
+
+```python
+@step
+def load_training_data(data_asset_ref: str) -> str:
+    # Keep the Azure asset reference explicit if version identity matters.
+    return data_asset_ref
+```
+
+**Migration warning**
+- If the asset version is part of governance or cross-workspace sharing, keep that Azure identity explicit.
+- If not, consider migrating the boundary to ZenML artifacts.
+
+## Registered Components and AzureML Registry
+
+**Classification:** redesign-only
+
+### AzureML
+
+```python
+component = ml_client.components.get(name="score_component", version="3")
+```
+
+### ZenML
+
+```python
+# Repackage the logic as importable Python code, or keep Azure Registry usage external.
+```
+
+**Migration warning**
+- ZenML has no cross-workspace Azure Registry equivalent.
+- Do not pretend registry-backed sharing semantics survive unchanged.
+
+## AutoML
+
+**Classification:** approximate
+
+### AzureML
+
+```python
+# Azure AutoML job used inside a broader AzureML workflow
+```
+
+### ZenML
+
+```python
+@step
+def run_azure_automl(config: dict[str, str]) -> str:
+    # Keep Azure AutoML as an explicit external call, or replace it with
+    # transparent training + HPO steps.
+    ...
+```
+
+**Migration warning**
+- AutoML can stay reachable from ZenML, but it is not a native ZenML primitive.

--- a/skills/zenml-azureml-migration/skills/azureml-migration/references/concept-map.md
+++ b/skills/zenml-azureml-migration/skills/azureml-migration/references/concept-map.md
@@ -1,0 +1,125 @@
+# AzureML SDK v2 -> ZenML Concept Map
+
+Complete mapping of Azure Machine Learning SDK v2 concepts to their ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (conceptual equivalent with different semantics), or **absent** (no safe ZenML equivalent -- needs redesign or should stay Azure-native).
+
+## Table of Contents
+
+- [Orchestration Primitives](#orchestration-primitives)
+- [Component Types](#component-types)
+- [Environments](#environments)
+- [Compute](#compute)
+- [Data Passing and Parameters](#data-passing-and-parameters)
+- [Control Flow and Scheduling](#control-flow-and-scheduling)
+- [Model Management and Deployment](#model-management-and-deployment)
+- [Azure Platform Features](#azure-platform-features)
+
+## Orchestration Primitives
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@pipeline` | `@pipeline`-decorated function | direct | Both define DAG-shaped workflows. ZenML expresses dependencies through step calls and artifact edges. |
+| Pipeline parameters with defaults | Pipeline function parameters with Python defaults | direct | One of the cleanest translations. |
+| Parameter override at submission time | Pipeline call / `.with_options(...)` / YAML config | direct | Same idea, different surface syntax. |
+| `default_compute=` on pipeline | `AzureMLOrchestratorSettings(...)` on the pipeline | approximate | Similar intent, but compute moves from the Azure pipeline DSL into orchestrator settings. |
+| `node.compute = ...` | Step-specific runtime configuration, step operator settings, or separate pipeline | approximate | Strongly heterogeneous per-node compute often needs deliberate redesign. |
+| `CommandComponent` as the main executable unit | `@step` | direct | This is the primary migration path when authoring in ZenML. |
+| Pipeline job submission | Running a ZenML pipeline on an AzureML-backed stack | approximate | Similar operational result, different authoring and control surfaces. |
+
+## Component Types
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@command_component` | `@step` | direct | Main translation path for Python-defined AzureML components. |
+| YAML component + `load_component()` | Rewrite as a Python `@step` | approximate | ZenML has YAML config, but not YAML-defined pipeline components as first-class reusable assets. |
+| Registered component | Python module/package, or keep Azure component external | absent | ZenML has no component registry equivalent. |
+| Component versioning | Git/package version + pipeline snapshot/build metadata | absent | Similar governance goal, different primitive. |
+| Pipeline component / sub-pipeline | Helper pipeline function or nested composition | approximate | Composition exists, but registered pipeline component assets do not. |
+| Sweep component / `.sweep()` | Call HPO tooling or Azure sweep API inside a step | absent | No native ZenML sweep job primitive. |
+| Parallel job / `parallel_run_function()` | Dynamic pipeline, `.map()`, or keep Azure job native | absent | Similar intent, not a safe 1:1 translation. |
+| Spark component | Keep Spark execution external, or wrap submission in a step | approximate | No first-class ZenML Spark component abstraction. |
+| AutoML job/component | Call Azure AutoML from a ZenML step, or replace with explicit training/HPO | approximate | Possible, but not native ZenML authoring. |
+| Import/data transfer component | Wrap Azure SDK call in a step, or redesign ingestion | approximate | Usually depends on whether Azure-native asset management is required. |
+
+## Environments
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Environment(image=..., conda_file=...)` | `DockerSettings(parent_image=..., requirements=...)` | approximate | Same goal, different abstraction. ZenML treats this as container config, not a registered environment asset. |
+| Curated environment | Prebuilt parent image | approximate | Similar operational outcome, but no curated environment catalog primitive in ZenML. |
+| Custom environment via build context | `DockerSettings(dockerfile=..., build_context_root=...)` | approximate | Operationally close. |
+| Environment asset registration/versioning | None | absent | Keep Azure environment assets if registry semantics matter. |
+| Azure environment image caching | Build/image reuse | approximate | Similar effect, different lifecycle and visibility. |
+
+## Compute
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Serverless compute | `mode="serverless"` | direct | Supported natively by the AzureML orchestrator. |
+| Compute instance | `mode="compute-instance"` | direct | Includes instance name/size and idle shutdown options. |
+| Compute cluster | `mode="compute-cluster"` | direct | Includes autoscaling and tier settings. |
+| GPU VM size | `size="Standard_NC6s_v3"` (or similar) | direct | Preserved directly in orchestrator settings. |
+| Dedicated / low-priority tier | `tier="Dedicated"` / `tier="LowPriority"` | direct | Good fit when keeping AzureML execution. |
+| Autoscaling min/max | `min_instances`, `max_instances` | direct | Direct mapping in cluster mode. |
+| Idle shutdown / scale-down | `idle_time_before_shutdown_minutes`, `idle_time_before_scaledown_down` | direct | Supported in compute instance / compute cluster modes respectively. |
+| Managed network isolation | Azure workspace configuration | approximate | Preserved externally because execution still happens inside AzureML. |
+| Attached Arc Kubernetes / Synapse Spark compute | None in AzureML orchestrator settings | absent | Not exposed as a first-class ZenML AzureML orchestrator mode. |
+
+## Data Passing and Parameters
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Primitive inputs (`string`, `number`, `integer`, `boolean`) | Normal Python parameters | direct | Safe and straightforward. |
+| Pipeline/component defaults | Python defaults | direct | Same intent. |
+| `Input` / `Output` with asset descriptors | Step parameters and return values | approximate | Similar dataflow role, different type system. |
+| `uri_file` | URI/path string or loaded Python object | approximate | Keep as a URI boundary when storage identity matters. |
+| `uri_folder` | URI/path string or loaded collection/object | approximate | Same pattern as `uri_file`. |
+| `mltable` | URI/reference or explicitly loaded DataFrame | approximate | No first-class MLTable type in ZenML. |
+| `mlflow_model` | ZenML model artifact or path string | approximate | Similar purpose, different model-management surface. |
+| `custom_model` / `triton_model` | Generic artifact or path | approximate | Usually handled as explicit artifacts or URIs. |
+| Data assets | ZenML artifacts, or explicit Azure asset IDs passed through | approximate | Decide whether the asset identity itself is important. |
+| Datastores | Artifact store / external storage configuration | approximate | Same storage concern, different abstraction boundary. |
+| Data versioning | Artifact lineage/versioning, or keep Azure data assets external | approximate | Depends on whether Azure asset registry semantics are required. |
+| Primitive outputs unsupported in AzureML | Primitive artifacts are normal in ZenML | direct | Behavioral difference that often simplifies the ZenML rewrite. |
+
+## Control Flow and Scheduling
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Standard DAG dependency by passing outputs to inputs | Standard artifact dependency | direct | Core DAG pattern matches well. |
+| Ordering without data transfer | Explicit dependency wiring / control dependency pattern | direct | ZenML can model ordering without pretending data exists. |
+| `if_else` | Dynamic branching or redesign | absent | Treat as unsafe for automatic translation here. |
+| `do_while` | Dynamic loop or keep loop inside one step | absent | Requires manual review and redesign. |
+| `parallel_for` | Dynamic `.map()` / manual fan-out | absent | Similar shape, different guarantees and limitations. |
+| `set_pipeline_controller_configurations` | None verified | absent | Treat as manual-review-only. |
+| `JobSchedule` + cron trigger | `Schedule(cron_expression=...)` | direct | Works when using the AzureML orchestrator. |
+| `JobSchedule` + recurrence trigger | `Schedule(start_time=..., interval_second=...)` | direct | Direct operational mapping. |
+| Event triggers | None | absent | Not a native ZenML schedule primitive. |
+| Update/delete Azure schedule through ZenML | Not native | absent | ZenML can create schedules, but lifecycle management remains manual on AzureML. |
+
+### Orchestrator scheduling support
+
+| Orchestrator | Scheduling support | Schedule types | Native schedule management |
+|---|:---:|---|:---:|
+| `AzureMLOrchestrator` | Yes | Cron, Interval | No |
+
+## Model Management and Deployment
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Model registration/versioning | ZenML `Model` plus optional Azure registration step | approximate | ZenML models are first-class, but they are not Azure Registry entries unless you explicitly create those. |
+| Managed online endpoint | No native equivalent | absent | Keep Azure-native, or call Azure SDK from a step. |
+| Managed online deployment | No native equivalent | absent | Same reasoning. |
+| Batch endpoint | No native equivalent | absent | Keep Azure-native if endpoint semantics matter. |
+| MLflow tracking | MLflow inside ZenML step / experiment tracker | direct | Good fit when AzureML already exposes MLflow tracking. |
+| MLflow model deployment to Azure endpoints | Azure SDK call from a ZenML step | approximate | Still possible, but it remains Azure deployment logic. |
+
+## Azure Platform Features
+
+| AzureML Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| AzureML Studio run UI | Still available when AzureML orchestrator is used | approximate | Preserved externally, not replaced by ZenML UI. |
+| Designer | None | absent | ZenML is code-first, not visual pipeline authoring. |
+| Responsible AI dashboard | None | absent | No equivalent dashboard workflow in ZenML. |
+| AzureML Registry | None | absent | ZenML workspaces are not equivalent to Azure cross-workspace asset registry semantics. |
+| Cross-workspace sharing of components/models/environments/data | None | absent | Keep Azure Registry if this is core to the operating model. |
+| Managed network isolation | Azure workspace setting | approximate | Preserved because jobs still run on AzureML. |

--- a/skills/zenml-azureml-migration/skills/azureml-migration/references/gaps-and-flags.md
+++ b/skills/zenml-azureml-migration/skills/azureml-migration/references/gaps-and-flags.md
@@ -1,0 +1,305 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the AzureML patterns that are most dangerous to silently approximate during migration -- the places where AzureML SDK v2 and ZenML behave differently enough that a naive translation changes the workflow's real behavior.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No AzureML Equivalent](#zenml-features-with-no-azureml-equivalent)
+- [Anti-Patterns in Migration](#anti-patterns-in-migration)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### AzureML environments with complex build and dependency semantics
+
+**What AzureML does**: `Environment(...)` objects can be reusable, registered assets with image + Conda semantics, curated environments, and Azure-managed build lifecycles.
+
+**Why it matters**: Environment identity may be part of governance, reuse, or reproducibility -- not just a Docker detail.
+
+**ZenML gap**: ZenML uses `DockerSettings`, not a first-class environment asset registry.
+
+**Recommended path**:
+- Translate the operational runtime into `DockerSettings`
+- Explicitly document the loss of Azure environment asset semantics
+- Keep Azure environment assets external if other teams still depend on them
+
+### Sweep jobs (HPO)
+
+**What AzureML does**: AzureML sweep jobs are first-class hyperparameter optimization primitives with Azure-native scheduling, metrics, and policy behavior.
+
+**Why it matters**: Replacing a sweep with a plain loop changes execution semantics, observability, and failure behavior.
+
+**ZenML gap**: No native sweep-job primitive.
+
+**Recommended path**:
+- Keep Azure sweep native and call it from a step, or
+- Redesign explicitly around Optuna or another HPO library
+
+### Parallel jobs for batch scoring
+
+**What AzureML does**: Azure parallel jobs are designed for large-scale mini-batch scoring and operational parallel inference.
+
+**Why it matters**: They are not just a generic for-each loop.
+
+**ZenML gap**: Dynamic pipelines and `.map()` can resemble fan-out, but they are not a safe semantic replacement.
+
+**Recommended path**:
+- Keep the Azure parallel job native, or
+- Redesign intentionally after validating partitioning, concurrency, retries, and output semantics
+
+### YAML-defined and registered components
+
+**What AzureML does**: YAML components and registered components act as reusable Azure assets with versions and potentially cross-team dependencies.
+
+**Why it matters**: The registry identity may matter as much as the code body.
+
+**ZenML gap**: ZenML has no component registry primitive.
+
+**Recommended path**:
+- Rewrite YAML-defined behavior as Python `@step` code
+- Keep Azure registered components external if downstream consumers still depend on them
+
+### MLTable and Azure data assets
+
+**What AzureML does**: MLTable and asset IDs can carry reproducibility, schema, storage, and governance meaning.
+
+**Why it matters**: Treating them as "just a pandas DataFrame" can erase an important contract.
+
+**ZenML gap**: No first-class MLTable or Azure data asset type.
+
+**Recommended path**:
+- Keep Azure asset references explicit when identity matters
+- Only collapse into ZenML artifacts when the asset identity is not part of the workflow contract
+
+### Managed online endpoints and batch endpoints
+
+**What AzureML does**: AzureML provides managed deployment primitives for serving and endpoint-based batch inference.
+
+**Why it matters**: Deployment is production behavior, not just authoring metadata.
+
+**ZenML gap**: No native Azure managed endpoint primitive.
+
+**Recommended path**:
+- Keep deployment Azure-native, or
+- Call Azure SDK APIs explicitly from a ZenML step
+
+### AzureML Registry, Responsible AI dashboard, and Designer
+
+**What AzureML does**:
+- AzureML Registry supports cross-workspace asset sharing
+- Responsible AI dashboard provides Azure-specific evaluation/reporting workflows
+- Designer provides visual pipeline authoring
+
+**Why it matters**: These are platform capabilities, not just syntax choices.
+
+**ZenML gap**: No direct equivalent for any of them.
+
+**Recommended path**:
+- Keep them Azure-native where required
+- Do not claim automatic migration for these features
+
+### Unverified control-flow helpers
+
+Treat these as **unsafe for automatic translation** in this skill:
+
+- `if_else`
+- `do_while`
+- `parallel_for`
+- `set_pipeline_controller_configurations`
+
+**Why it matters**: This skill does not treat them as stable, verified 1:1 migration surfaces.
+
+**Recommended path**:
+- Flag them as manual-review-only
+- Redesign deliberately using ZenML dynamic pipelines only if the user explicitly accepts a redesign
+
+### Strongly heterogeneous per-node compute
+
+**What AzureML does**: The pipeline DSL can express node-level compute choices cleanly.
+
+**Why it matters**: A literal rewrite can hide the fact that the original pipeline depended on meaningful compute heterogeneity.
+
+**ZenML gap**: ZenML can preserve a lot of Azure compute via the AzureML orchestrator, but per-node heterogeneity is not a simple like-for-like DSL property.
+
+**Recommended path**:
+- Consider separate pipelines, step operators, or explicit runtime config
+- Flag when compute specialization is core to correctness or cost behavior
+
+---
+
+## Behavioral Differences
+
+### Execution model
+
+| Aspect | AzureML SDK v2 | ZenML |
+|---|---|---|
+| **Authoring model** | Asset-centric (components, environments, compute, assets) | Python-workflow-centric (`@step`, `@pipeline`) |
+| **Main reusable unit** | Registered components and environments | Python code, Docker config, stack config |
+| **Execution target** | AzureML jobs | Orchestrator-managed steps, optionally still on AzureML |
+| **Run inspection** | AzureML Studio | ZenML dashboard plus backend-specific UI |
+
+### Environment management
+
+| Aspect | AzureML | ZenML |
+|---|---|---|
+| **Primary primitive** | `Environment(...)` asset | `DockerSettings(...)` |
+| **Registry semantics** | Yes | No first-class equivalent |
+| **Curated images** | Azure curated environments | Prebuilt parent images |
+| **Build context** | Azure-aware environment build | Docker build config in code |
+
+### Compute management
+
+| Aspect | AzureML | ZenML |
+|---|---|---|
+| **Pipeline-level compute** | `default_compute` | Orchestrator settings |
+| **Node-level compute** | `node.compute = ...` | Runtime config / step operator / redesign |
+| **Serverless/instance/cluster** | Native Azure modes | Preserved via AzureML orchestrator |
+| **Schedule lifecycle** | Azure-managed | ZenML can create schedules, but lifecycle management is limited afterward |
+
+### Data handling
+
+| Aspect | AzureML | ZenML |
+|---|---|---|
+| **Type surface** | Asset descriptors (`uri_file`, `uri_folder`, `mltable`, model assets) | Python parameters, artifacts, materializers |
+| **Primitive outputs** | Limited / asset-oriented | Normal and ergonomic |
+| **Versioning story** | Azure asset registry/versioning | Artifact lineage/versioning |
+| **Governance boundary** | Asset identity often explicit | Identity often moves into code/config unless preserved deliberately |
+
+### Control flow
+
+| Aspect | AzureML | ZenML |
+|---|---|---|
+| **Standard DAG edges** | Native | Native |
+| **Conditional helpers** | Azure helper APIs exist | Dynamic pipelines / redesign |
+| **Loop/fan-out helpers** | Azure helper APIs / parallel abstractions | Dynamic pipelines / `.map()` / redesign |
+| **Auto-translation safety** | Mixed | Unsafe for the helper APIs listed above |
+
+### Model management and deployment
+
+| Aspect | AzureML | ZenML |
+|---|---|---|
+| **Model registration** | Azure model assets | ZenML `Model` plus optional Azure registration |
+| **Managed endpoints** | Native Azure deployment primitives | No native equivalent |
+| **MLflow** | First-class integration available | Works well inside ZenML steps / experiment tracker |
+| **Cross-workspace sharing** | Azure Registry | No direct equivalent |
+
+---
+
+## Migration Decision Tree
+
+Text-based decision procedure for translating AzureML SDK v2 workflows to ZenML.
+
+```text
+INPUT: azure_object_type, compute_requirements, environment_usage,
+       data_asset_requirements, deployment_requirements, control_flow_helpers
+
+WORKFLOW SHAPE:
+  IF object is an @pipeline with standard component edges:
+    EMIT @pipeline
+    MAP pipeline parameters -> typed Python parameters
+  ELSE:
+    FLAG MANUAL_ANALYSIS_REQUIRED
+
+COMPONENTS:
+  IF component is @command_component:
+    EMIT @step
+  ELSE IF component is YAML + load_component():
+    REWRITE as Python @step
+    FLAG warn YAML_COMPONENT_REWRITTEN
+  ELSE IF component is registered Azure component:
+    FLAG blocker REGISTRY_SEMANTICS_PRESENT
+    DECIDE: keep Azure component external OR repackage as Python code
+
+ENVIRONMENTS:
+  IF environment is image + conda only:
+    MAP -> DockerSettings(parent_image=..., requirements=...)
+  ELSE IF environment depends on curated/registered environment semantics:
+    MAP runtime intent -> DockerSettings
+    FLAG warn ENVIRONMENT_ASSET_SEMANTICS_LOST
+
+COMPUTE:
+  IF workflow should keep Azure execution:
+    MAP serverless / compute-instance / compute-cluster
+      -> AzureMLOrchestratorSettings(mode=...)
+  IF node-level heterogeneous compute is important:
+    FLAG warn PER_NODE_COMPUTE_REDESIGN
+    DECIDE: separate pipelines, step operator, or explicit runtime config
+
+DATA:
+  IF inputs/outputs are primitive parameters:
+    MAP directly to typed Python params
+  IF assets are uri_file / uri_folder / mltable / model assets:
+    IF asset identity matters for governance or cross-team reuse:
+      KEEP Azure asset reference explicit
+      FLAG warn ASSET_IDENTITY_PRESERVED_EXTERNALLY
+    ELSE:
+      MAP to artifacts or loaded Python objects
+
+ADVANCED JOB TYPES:
+  IF workflow uses sweep jobs:
+    FLAG blocker SWEEP_REQUIRES_REDESIGN
+  IF workflow uses parallel jobs:
+    FLAG blocker PARALLEL_JOB_REQUIRES_REDESIGN
+  IF workflow uses AutoML:
+    FLAG warn AUTOML_EXTERNAL_CALL
+    DECIDE: keep Azure AutoML external OR replace with explicit training/HPO
+
+CONTROL FLOW:
+  IF helper in {if_else, do_while, parallel_for, set_pipeline_controller_configurations}:
+    FLAG blocker CONTROL_FLOW_UNSAFE_FOR_AUTO_TRANSLATION
+    REQUIRE manual redesign review
+
+SCHEDULING:
+  IF schedule is cron or recurrence AND target is AzureML orchestrator:
+    EMIT Schedule(...)
+    FLAG warn AZURE_SCHEDULE_LIFECYCLE_MANUAL
+  ELSE IF schedule depends on broader Azure schedule management expectations:
+    FLAG warn SCHEDULE_GOVERNANCE_REVIEW
+
+DEPLOYMENT:
+  IF workflow deploys managed online or batch endpoints:
+    FLAG blocker AZURE_DEPLOYMENT_STAYS_NATIVE
+    DECIDE: keep Azure-native OR call Azure SDK from a ZenML step
+
+PLATFORM FEATURES:
+  IF workflow depends on AzureML Registry, Responsible AI dashboard, or Designer:
+    FLAG blocker PLATFORM_FEATURE_NO_ZENML_EQUIVALENT
+```
+
+---
+
+## ZenML Features with No AzureML Equivalent
+
+These are capabilities the user gains after migration -- include relevant ones in the "What You Get for Free" section of the migration report.
+
+| ZenML Feature | Description |
+|---|---|
+| **First-class typed artifacts** | Persist and version rich Python objects, not just Azure asset descriptors. |
+| **Step caching** | Skip re-execution when inputs and code have not changed. |
+| **Stack abstraction** | Same pipeline code can target local, Kubernetes, Vertex, SageMaker, AzureML, and more by changing the stack. |
+| **Model Control Plane** | Manage models, lineage, and promotion workflows beyond raw registry entries. |
+| **Service connectors** | Unified cloud authentication patterns with token refresh and secret handling. |
+| **Step and pipeline hooks** | Attach cross-cutting logic like notifications without dedicated orchestration nodes. |
+| **Project-oriented code reuse** | Reuse Python modules and pipeline code instead of relying on Azure component assets. |
+| **Artifact lineage graph** | Track provenance across runs in a way that is more pipeline-native than asset registration alone. |
+
+---
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Copying AzureML assets into ZenML names 1:1 | Preserves the old mental model but hides architectural changes | Rewrite around `@step`, `@pipeline`, artifacts, and orchestrator settings |
+| Treating `Environment(...)` as if it were still a registry-backed object | ZenML does not have that primitive | Translate runtime intent into `DockerSettings` and document the semantic change |
+| Converting sweep jobs into Python loops | Changes search execution semantics | Keep Azure sweep native, or redesign around explicit HPO tooling |
+| Converting parallel jobs directly into `.map()` | Similar shape, different runtime guarantees | Flag and redesign intentionally |
+| Treating MLTable as a native ZenML type | It is not | Keep the Azure boundary explicit or load it deliberately in-step |
+| Dropping Azure deployment logic from the migrated workflow | Changes production behavior | Keep endpoints Azure-native or call Azure SDK from steps |
+| Pretending `if_else` / `do_while` are safe 1:1 rewrites | This skill does not verify that | Flag them and require manual review |
+| Ignoring schedule lifecycle after ZenML creates an Azure schedule | Leads to operational surprises later | Document ownership of updates/deletes in the migration report |

--- a/skills/zenml-dagster-migration/plugin.json
+++ b/skills/zenml-dagster-migration/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "zenml-dagster-migration",
+  "version": "1.0.0",
+  "description": "Migrate Dagster assets, ops, jobs, and asset-graph workflows to idiomatic ZenML pipelines with concept mapping, asset-boundary planning, code translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "dagster",
+    "migration",
+    "mlops",
+    "pipelines",
+    "assets",
+    "orchestration"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-dagster-migration/skills/dagster-migration/SKILL.md
+++ b/skills/zenml-dagster-migration/skills/dagster-migration/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: dagster-to-zenml-migration
+description: >-
+  Migrate Dagster assets, ops, graphs, jobs, and software-defined asset
+  workflows to idiomatic ZenML pipelines. Handles concept mapping
+  (asset->step output, job->pipeline, IOManager->artifact store/materializer +
+  explicit IO steps), asset-boundary planning, code translation, scheduling,
+  retry config, resources/config migration, and flags unsupported patterns
+  (asset selection, partitions/backfills, sensors, declarative automation,
+  freshness policies, observable source assets) for human review. Use this
+  skill whenever the user mentions Dagster migration, converting Dagster assets
+  or jobs, porting workflows from Dagster, replacing Dagster with ZenML, or
+  asks how a Dagster concept maps to ZenML -- even if they do not explicitly
+  say "migrate". Also use when they paste Dagster code and ask to make it work
+  with ZenML, or when they describe a workflow using Dagster terminology
+  (`@asset`, `@multi_asset`, `Definitions`, `IOManager`, `ConfigurableResource`,
+  partitions, sensors, asset checks) in a ZenML context. If the user just asks
+  a quick conceptual question ("what is the ZenML equivalent of an IOManager?"
+  or "how should I think about Dagster assets in ZenML?"), answer it directly
+  from the concept map -- no need to run the full migration workflow.
+---
+
+# Migrate Dagster to ZenML
+
+This skill translates Dagster projects into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing Dagster code, classifying each pattern, deciding where Dagster asset boundaries become ZenML pipeline boundaries, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project.
+
+## How migration works at a high level
+
+Dagster and ZenML are both orchestration systems, but they organize work around different primary objects.
+
+- **Dagster** increasingly centers the world around **assets**: named data products, asset checks, partitions, asset selections, and policies that decide when assets should materialize.
+- **ZenML** centers the world around **pipelines and steps**: Python-defined execution graphs that produce typed artifacts, backed by stack components and artifact lineage.
+
+That means a Dagster -> ZenML migration is not mainly a decorator rename. The hard part is semantic:
+
+- deciding what the true **execution unit** is,
+- deciding where a Dagster asset graph should become **one pipeline vs multiple pipelines**, and
+- deciding which orchestration features are safe to preserve vs which must be redesigned.
+
+Think of it like moving a library into a workshop. In Dagster, the shelves themselves are the first-class object. In ZenML, the assembly line is the first-class object. The books may stay the same, but the floor plan changes.
+
+### The three mapping types
+
+Every Dagster concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in migration report |
+| **Absent** | No ZenML equivalent | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Dagster Code
+
+Ask the user for their Dagster codebase, or the relevant files if it is too large. Read the code thoroughly before doing anything else. Inventory the project in two passes:
+
+#### 1. Classify the project style
+
+Determine whether the codebase is primarily:
+
+- **Asset-centric** -- mostly `@asset`, `@multi_asset`, `define_asset_job`, asset checks, partitions, and asset automation
+- **Op/job-centric** -- mostly `@op`, `@graph`, `@job`
+- **Mixed** -- asset graph plus legacy ops/jobs or helper graphs
+
+This matters because `@op` / `@job` code usually maps more cleanly to ZenML than asset-heavy code.
+
+#### 2. Inventory the important Dagster patterns
+
+For each module, identify:
+
+1. **Core primitives** -- `@asset`, `@multi_asset`, `@graph_asset`, `@graph_multi_asset`, `@op`, `@graph`, `@job`, `Definitions`
+2. **Dependency structure** -- asset deps, graph composition, asset jobs, asset selection
+3. **Data and IO** -- `IOManager`, `ConfigurableIOManager`, `SourceAsset`, observable source assets, metadata, asset checks
+4. **Config and resources** -- `Config`, `RunConfig`, `ConfigurableResource`, `EnvVar`
+5. **Execution semantics** -- partitions, partition mappings, backfills, schedules, sensors, asset sensors, declarative automation, freshness policies
+6. **Dynamic behavior** -- `DynamicOut`, `DynamicOutput`, runtime fan-out, asset subsets, dynamic partitions
+7. **Infrastructure** -- executors, launchers, Docker/Kubernetes settings, resource tags
+8. **Testing patterns** -- how Dagster execution and checks are currently tested
+
+When the codebase uses asset-heavy features, open [references/gaps-and-flags.md](references/gaps-and-flags.md) early. That file is the safety rail for migration.
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it using the mapping type (direct / approximate / absent). Use the quick guide below and the full tables in [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+**Direct translations (translate automatically):**
+- `@op` -> `@step`
+- simple `@job` -> `@pipeline`
+- `RetryPolicy` -> `StepRetryConfig`
+- typed config values -> typed pipeline/step parameters
+
+**Approximate translations (translate with caveats):**
+- `@asset` -> step output artifact inside a pipeline
+- `@multi_asset` -> multi-output step
+- `@graph_asset` -> helper steps plus a terminal output artifact
+- `ConfigurableResource` -> stack components + secrets + service connectors + step-local helper objects
+- schedules -> `Schedule(...)` on supported orchestrators
+- `IOManager` -> artifact store/materializer plus explicit source/sink steps
+- `SourceAsset` -> `ExternalArtifact` or explicit source-loading step
+- asset-check logic -> validation step body, but without Dagster's independently managed check-node semantics
+- `DynamicOutput` fan-out -> dynamic pipeline or explicit redesign
+
+**Absent / needs redesign (flag for human review):**
+- asset selection and subset materialization semantics
+- partition mappings and non-trivial partition/backfill behavior
+- declarative automation / auto-materialize policies
+- freshness policies as first-class orchestration rules
+- sensors and asset sensors
+- observable source assets as first-class graph nodes
+- IO managers that embed business logic beyond serialization
+- `@multi_asset` subset semantics
+
+#### Mandatory pipeline-boundary decision
+
+Before writing any code, make an explicit decision about the migration shape. This is the single most important Dagster-specific step.
+
+Choose one of these:
+
+1. **Single ZenML pipeline**
+   - Use only when the Dagster code already behaves like one tightly coupled execution unit.
+   - Common for op/job-centric projects or very small asset graphs.
+
+2. **Multiple ZenML pipelines in one migrated project**
+   - Use when the original Dagster project relies on asset selection, different schedules, different ownership boundaries, or distinct backfill domains.
+   - This is often the honest choice for asset-heavy code.
+
+3. **Partial migration + flagged redesign**
+   - Use when unsupported Dagster semantics dominate.
+   - In this case, generate only the safe core, add `# TODO(migration)` markers, and make the redesign requirements explicit.
+
+Present this decision clearly to the user before generating code:
+
+> "Here is the migration shape I recommend:
+> - **Pipeline boundary decision**: [single pipeline / multiple pipelines / partial migration]
+> - **Why**: [concrete explanation tied to the Dagster code]
+> - **Direct translations**: [list]
+> - **Approximate translations**: [list]
+> - **Needs redesign**: [list with brief explanation]
+>
+> Shall I proceed with this migration plan?"
+
+If there are HIGH-severity flags, explain each one concretely: what the Dagster code does, why ZenML cannot replicate it directly, and what redesign would preserve the intent most honestly.
+
+### Phase 3: Generate ZenML Code
+
+Translate the Dagster project into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+├── pipelines/
+│   ├── __init__.py
+│   ├── main_pipeline.py
+│   └── extra_pipeline.py     # If the Dagster project becomes multiple pipelines
+├── materializers/            # Custom materializers (if needed)
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+This matches the `zenml-pipeline-authoring` skill's conventions. Key rules:
+- One step per file in `steps/`
+- Separate pipeline definition from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` uses `zenml>=0.94.1` and `requires-python = ">=3.12"`
+- Run `zenml init` at the project root
+- Always generate `configs/dev.yaml` and `configs/prod.yaml`
+- Always generate a `README.md` explaining the migrated pipeline(s), how to run them, and what still needs manual attention
+- Add concise `# Migration note:` comments for semantic differences
+- Add `# TODO(migration):` comments only where genuine redesign work remains
+
+#### Multiple pipelines are allowed
+
+Unlike Airflow- or Databricks-style migrations, a Dagster migration may honestly need **multiple** ZenML pipelines. Do not force a single pipeline just for symmetry.
+
+#### `run.py` behavior
+
+- If exactly one pipeline is generated, `run.py` may run that pipeline by default.
+- If multiple pipelines are generated, `run.py` should expose a `--pipeline` argument so the user can choose which pipeline entry point to run.
+- If partitions or operational slices mattered in Dagster, `run.py` should also expose the relevant parameters (`--partition-key`, `--start-date`, `--end-date`, etc.).
+
+#### Core translation rule
+
+Move the compute body into a `@step` function, type-hint the inputs and outputs, and wire steps through function calls in a `@pipeline`.
+
+See [references/code-patterns.md](references/code-patterns.md) for side-by-side examples covering:
+- asset graphs
+- op/job workflows
+- IO managers
+- resources/config
+- partitions
+- schedules
+- sensors
+- asset checks
+- `@multi_asset`, `@graph_asset`, and dynamic fan-out
+
+#### Handling approximate translations
+
+When translating approximate patterns, add brief inline comments in the generated code explaining the semantic difference:
+
+```python
+@step
+def load_orders() -> pd.DataFrame:
+    # Migration note: the original Dagster asset could be materialized
+    # independently inside the asset graph. In ZenML this data is produced
+    # as part of a pipeline run and persisted as an artifact.
+    ...
+```
+
+#### Handling absent patterns
+
+For patterns that have no ZenML equivalent, do NOT silently approximate them. Instead:
+
+1. Add a clearly marked `# TODO(migration)` comment in the generated code
+2. Include the pattern in the migration report
+3. Suggest a redesign approach
+
+Example:
+
+```python
+# TODO(migration): UNSUPPORTED -- Dagster asset selection / subset materialization
+# was part of the original workflow here. ZenML does not support first-class
+# asset selection semantics. Recommended redesign: split the asset group into
+# separate pipelines and load shared upstream results via ExternalArtifact or
+# an explicit source step.
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root:
+
+```markdown
+# Migration Report: [Dagster Project] -> [ZenML Project]
+
+## Summary
+- **Source**: Dagster project `[name]`
+- **Target**: ZenML project `[name]`
+- **Project style**: asset-centric / op-job-centric / mixed
+- **Components migrated**: X direct, Y approximate, Z flagged
+
+## Pipeline Boundary Decisions
+| Dagster run unit / asset slice | ZenML pipeline | Why split or combine |
+|---|---|---|
+| daily_orders assets | pipelines/orders_daily.py | Dagster users materialized this slice independently |
+
+## Direct Translations
+| Dagster Component | ZenML Component | Notes |
+|---|---|---|
+| `train_model` op | `steps/train_model.py` | Clean op -> step translation |
+
+## Approximate Translations
+| Dagster Component | ZenML Component | What Changed |
+|---|---|---|
+| `cleaned_orders` asset | `steps/clean_orders.py` | Asset became a step output artifact inside a pipeline |
+| warehouse IOManager | `steps/load_orders.py` + artifact store | Business logic moved from IO manager into explicit step |
+
+## Flagged for Review
+| Dagster Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| Asset selection | HIGH | No first-class subset materialization in ZenML | Split into multiple pipelines |
+| Daily partitions + partition mappings | HIGH | No native partition engine | Explicit partition-key params + external backfill driver |
+| Sensor cursor | HIGH | No sensor/cursor API | External event trigger service |
+
+## IO / Storage Migration
+[Summarize what was preserved and what moved out of IO managers]
+
+## Partition / Backfill Strategy
+[Explain how partition keys and backfills are handled after migration]
+
+## Automation and Scheduling Gaps
+[Explain schedules, sensors, freshness, declarative automation, and what changed]
+
+## What's NOT Migrated
+[List the Dagster semantics or platform features left outside the migrated code]
+
+## What You Get for Free After Migration
+- **Artifact versioning and lineage**
+- **Step caching**
+- **Stack abstraction**
+- **Service connectors**
+- **Model Control Plane** (if relevant)
+
+## Recommended Next Steps
+1. Run the `zenml-quick-wins` skill for metadata logging, experiment tracking, and alerters
+2. Install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`
+3. Follow the docs links for flagged patterns
+4. Use `zenml-pipeline-authoring` for deeper customization
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a "Recommended Next Steps" section in the migration report AND communicate it to the user.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+Always suggest this as the immediate next step:
+
+> "Now that the migration is done, I recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerts, and other production improvements."
+
+#### 2. Documentation links for flagged patterns
+
+For every flagged pattern, include relevant ZenML documentation links. Prefer stable, high-level docs areas when the exact implementation path depends on the user's stack:
+
+- Artifact management / external artifacts: `https://docs.zenml.io/user-guides/starter-guide/manage-artifacts`
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- Scheduling: `https://docs.zenml.io/concepts/steps_and_pipelines/scheduling`
+- Pipeline deployments / service-style triggering: `https://docs.zenml.io/concepts/deployment`
+- Orchestrators and scheduling: `https://docs.zenml.io/stacks/orchestrators`
+- Service connectors: `https://docs.zenml.io/stacks/service-connectors`
+- Best practices / access management: `https://docs.zenml.io/user-guides/best-practices`
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML documentation while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Community support for unsupported patterns
+
+When the migration has **2+ HIGH-severity flags**, generate a pre-made Slack message for `zenml.io/slack`. Include:
+- what Dagster code is being migrated,
+- the specific unsupported patterns,
+- the workarounds already attempted, and
+- what the user wants help deciding.
+
+#### 5. Open GitHub issues for genuine feature gaps
+
+When the migration reveals a genuine missing feature in ZenML -- not just "this works differently", but a real capability gap that multiple users would benefit from -- offer to open a GitHub issue on `zenml-io/zenml`.
+
+#### 6. Run `/simplify` on the generated code
+
+After migration is complete, always suggest running `/simplify` on the generated code to reduce migration noise, consolidate repetitive helper code, and make the result feel more like production code.
+
+#### 7. Further customization via `zenml-pipeline-authoring`
+
+Use `zenml-pipeline-authoring` for:
+- Docker settings and remote execution
+- YAML configuration
+- custom materializers
+- deployment and post-migration cleanup
+
+## Important Behavioral Differences to Communicate
+
+These are the most common sources of confusion after migration. Always mention the relevant ones in the migration report.
+
+### Assets are not steps
+
+A Dagster asset is a named data product with graph semantics around materialization, selection, partitions, and checks. A ZenML step is a unit of compute. The closest migration shape is usually:
+
+- Dagster asset **compute body** -> ZenML `@step`
+- Dagster asset **identity** -> artifact name or step output name
+- Dagster asset **graph selection semantics** -> pipeline boundaries plus explicit source/loading patterns
+
+### IO managers are not just materializers
+
+If the original Dagster IO manager says, in effect, "when someone asks for this asset, go load table X from warehouse Y", then the real story is not serialization. The real story is data access logic. That logic usually belongs in a ZenML source/sink step, not only in a materializer.
+
+### Partition keys are just the label, not the whole engine
+
+Passing `partition_key="2026-04-07"` into a ZenML pipeline preserves the label. It does not automatically preserve partition mappings, backfills, freshness, or asset-reconciliation rules. Those must be rebuilt explicitly.
+
+### Sensors become trigger systems, not steps that wait forever
+
+A Dagster sensor is usually better reimagined as an external trigger or polling service. Otherwise you risk turning a lightweight orchestration rule into an expensive long-running container.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it is wrong | What to do instead |
+|---|---|---|
+| Treating every asset as its own pipeline | Destroys meaningful execution grouping | Group assets by real operational boundary |
+| Forcing the entire asset graph into one pipeline | Hides the loss of subset materialization semantics | Split into multiple pipelines when needed |
+| Translating every IOManager into a materializer | Loses business/data-access behavior | Separate serialization from explicit source/sink logic |
+| Replacing sensors with infinite polling steps | Burns compute and changes operational behavior | Use external triggers or bounded polling logic |
+| Collapsing partition logic into a single untyped string without documenting the loss | Drops critical orchestration semantics | Preserve partition parameters explicitly and document gaps |
+| Treating asset checks as comments instead of executable validation | Loses enforcement | Create validation steps and log metadata |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- Full concept mapping tables and scheduling support matrix
+- [references/code-patterns.md](references/code-patterns.md) -- Side-by-side code translations for the major Dagster patterns
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- Must-flag patterns, behavioral differences, and the migration decision tree
+
+### Product documentation
+
+- Dagster docs: `https://docs.dagster.io/`
+- ZenML docs: `https://docs.zenml.io/`

--- a/skills/zenml-dagster-migration/skills/dagster-migration/references/code-patterns.md
+++ b/skills/zenml-dagster-migration/skills/dagster-migration/references/code-patterns.md
@@ -1,0 +1,597 @@
+# Code Translation Patterns
+
+Side-by-side Dagster -> ZenML translations for the major migration patterns. Each example shows the Dagster source, the ZenML translation, and the key semantic differences that still matter after the code is converted.
+
+## Table of Contents
+
+- [Simple asset graph -> single pipeline](#simple-asset-graph---single-pipeline)
+- [Op / graph / job -> pipeline](#op--graph--job---pipeline)
+- [IO manager -> explicit source and sink steps](#io-manager---explicit-source-and-sink-steps)
+- [ConfigurableResource -> secrets, connectors, and helper objects](#configurableresource---secrets-connectors-and-helper-objects)
+- [Config / RunConfig -> typed parameters and YAML config](#config--runconfig---typed-parameters-and-yaml-config)
+- [Partitioned asset -> parameterized pipeline](#partitioned-asset---parameterized-pipeline)
+- [Schedule -> `Schedule(...)`](#schedule---schedule)
+- [Sensor -> external trigger pattern](#sensor---external-trigger-pattern)
+- [Asset check -> validation step](#asset-check---validation-step)
+- [multi_asset -> multi-output step](#multi_asset---multi-output-step)
+- [graph_asset -> helper steps inside a pipeline](#graph_asset---helper-steps-inside-a-pipeline)
+- [DynamicOutput fan-out -> dynamic pipeline or redesign](#dynamicoutput-fan-out---dynamic-pipeline-or-redesign)
+
+---
+
+## Simple asset graph -> single pipeline
+
+This is the cleanest asset-style migration: one small Dagster asset graph that already behaves like one execution unit.
+
+### Dagster
+
+```python
+import dagster as dg
+import pandas as pd
+
+
+@dg.asset
+def raw_orders() -> pd.DataFrame:
+    return pd.DataFrame({"order_id": [1, 2], "amount": [10.0, 20.0]})
+
+
+@dg.asset
+def cleaned_orders(raw_orders: pd.DataFrame) -> pd.DataFrame:
+    return raw_orders.assign(amount_usd=raw_orders["amount"].fillna(0.0))
+
+
+@dg.asset
+def order_summary(cleaned_orders: pd.DataFrame) -> dict[str, float]:
+    return {"total": float(cleaned_orders["amount_usd"].sum())}
+```
+
+### ZenML
+
+```python
+from __future__ import annotations
+
+from typing import Annotated
+
+import pandas as pd
+from zenml import pipeline, step
+
+
+@step
+def raw_orders() -> Annotated[pd.DataFrame, "raw_orders"]:
+    return pd.DataFrame({"order_id": [1, 2], "amount": [10.0, 20.0]})
+
+
+@step
+def cleaned_orders(raw_orders: pd.DataFrame) -> Annotated[pd.DataFrame, "cleaned_orders"]:
+    return raw_orders.assign(amount_usd=raw_orders["amount"].fillna(0.0))
+
+
+@step
+def order_summary(cleaned_orders: pd.DataFrame) -> dict[str, float]:
+    return {"total": float(cleaned_orders["amount_usd"].sum())}
+
+
+@pipeline
+def orders_pipeline() -> None:
+    raw = raw_orders()
+    cleaned = cleaned_orders(raw)
+    order_summary(cleaned)
+```
+
+**Key differences**:
+- The Dagster assets were first-class graph nodes. In ZenML, these become step outputs produced inside one pipeline run.
+- If the original team materialized `cleaned_orders` independently, this translation is only approximate; split the graph into multiple pipelines instead.
+
+---
+
+## Op / graph / job -> pipeline
+
+Op/job-centric Dagster code usually maps more directly because the source model already centers execution units.
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.op
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+
+@dg.op
+def transform(numbers: list[int]) -> list[int]:
+    return [n * 10 for n in numbers]
+
+
+@dg.op
+def load(numbers: list[int]) -> None:
+    print(numbers)
+
+
+@dg.graph
+def etl_graph():
+    load(transform(extract()))
+
+
+etl_job = etl_graph.to_job(name="etl_job")
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+
+@step
+def transform(numbers: list[int]) -> list[int]:
+    return [n * 10 for n in numbers]
+
+
+@step
+def load(numbers: list[int]) -> None:
+    print(numbers)
+
+
+@pipeline
+def etl_pipeline() -> None:
+    load(transform(extract()))
+```
+
+**Key differences**:
+- This is close to a direct translation.
+- Dagster graph/job objects disappear; ZenML uses plain Python composition inside the pipeline function.
+
+---
+
+## IO manager -> explicit source and sink steps
+
+This is the pattern where migrations often go wrong. If the IO manager contains data-access behavior, move that behavior into steps.
+
+### Dagster
+
+```python
+import dagster as dg
+import pandas as pd
+
+
+class WarehouseIOManager(dg.IOManager):
+    def handle_output(self, context, obj: pd.DataFrame) -> None:
+        obj.to_parquet(f"/warehouse/{context.asset_key.path[-1]}.parquet")
+
+    def load_input(self, context) -> pd.DataFrame:
+        upstream_name = context.upstream_output.asset_key.path[-1]
+        return pd.read_parquet(f"/warehouse/{upstream_name}.parquet")
+
+
+@dg.asset(io_manager_key="warehouse_io")
+def orders() -> pd.DataFrame:
+    return pd.DataFrame({"order_id": [1, 2]})
+
+
+@dg.asset(io_manager_key="warehouse_io")
+def order_count(orders: pd.DataFrame) -> int:
+    return len(orders)
+```
+
+### ZenML
+
+```python
+from __future__ import annotations
+
+import pandas as pd
+from zenml import pipeline, step
+
+
+@step
+def load_orders_from_warehouse() -> pd.DataFrame:
+    # Migration note: the original Dagster IOManager controlled upstream loading.
+    # In ZenML, that data-access behavior is now explicit.
+    return pd.read_parquet("/warehouse/orders.parquet")
+
+
+@step
+def compute_order_count(orders: pd.DataFrame) -> int:
+    return len(orders)
+
+
+@step
+def persist_order_count(order_count: int) -> None:
+    with open("/warehouse/order_count.txt", "w") as f:
+        f.write(str(order_count))
+
+
+@pipeline
+def orders_pipeline() -> None:
+    orders = load_orders_from_warehouse()
+    count = compute_order_count(orders)
+    persist_order_count(count)
+```
+
+**Key differences**:
+- The load/write behavior is now explicit step logic.
+- Use a materializer only for serialization concerns, not as a hiding place for business-specific warehouse conventions.
+
+**Migration warning**:
+- If the IO manager encoded lazy loading, environment routing, or partition-aware path resolution, flag it for review.
+
+---
+
+## ConfigurableResource -> secrets, connectors, and helper objects
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+class ApiResource(dg.ConfigurableResource):
+    base_url: str
+    api_key: str
+
+    def fetch(self, endpoint: str) -> dict:
+        return {"endpoint": endpoint, "base_url": self.base_url}
+
+
+@dg.asset
+def customer_snapshot(api: ApiResource) -> dict:
+    return api.fetch("/customers")
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+
+class ApiClient:
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+
+    def fetch(self, endpoint: str) -> dict:
+        return {"endpoint": endpoint, "base_url": self.base_url}
+
+
+@step
+def customer_snapshot(base_url: str, api_key: str) -> dict:
+    client = ApiClient(base_url=base_url, api_key=api_key)
+    return client.fetch("/customers")
+```
+
+**Key differences**:
+- In Dagster, the framework injects the resource.
+- In ZenML, make the dependency explicit and decide separately where the values come from: pipeline params, YAML config, secrets, or service connectors.
+
+---
+
+## Config / RunConfig -> typed parameters and YAML config
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+class TrainConfig(dg.Config):
+    learning_rate: float
+    epochs: int
+
+
+@dg.asset
+def train_model(config: TrainConfig) -> dict:
+    return {"lr": config.learning_rate, "epochs": config.epochs}
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def train_model(learning_rate: float, epochs: int) -> dict:
+    return {"lr": learning_rate, "epochs": epochs}
+
+
+@pipeline
+def training_pipeline(learning_rate: float, epochs: int) -> None:
+    train_model(learning_rate=learning_rate, epochs=epochs)
+```
+
+**Key differences**:
+- Dagster config object becomes explicit typed parameters.
+- Environment-specific values can live in `configs/dev.yaml` and `configs/prod.yaml`.
+
+---
+
+## Partitioned asset -> parameterized pipeline
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+daily = dg.DailyPartitionsDefinition(start_date="2024-01-01")
+
+
+@dg.asset(partitions_def=daily)
+def sales_for_day(context: dg.AssetExecutionContext) -> str:
+    return context.partition_key
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def sales_for_day(partition_key: str) -> str:
+    # Migration note: this preserves the partition label, not Dagster's
+    # partition engine, mappings, or backfill semantics.
+    return partition_key
+
+
+@pipeline
+def sales_pipeline(partition_key: str) -> None:
+    sales_for_day(partition_key=partition_key)
+```
+
+**Key differences**:
+- This preserves the partition key, not the full partition orchestration model.
+- Non-trivial partition mappings or coordinated backfills should be flagged, not silently collapsed into a parameter.
+
+---
+
+## Schedule -> `Schedule(...)`
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.schedule(cron_schedule="0 2 * * *", job=my_job)
+def daily_schedule(_context: dg.ScheduleEvaluationContext):
+    return {}
+```
+
+### ZenML
+
+```python
+from zenml.config.schedule import Schedule
+
+
+schedule = Schedule(cron_expression="0 2 * * *")
+my_pipeline.with_options(schedule=schedule)()
+```
+
+**Key differences**:
+- ZenML scheduling support is orchestrator-dependent.
+- The current ZenML scheduling docs list support for Airflow, AzureML, Databricks, HyperAI, Kubeflow, Kubernetes, SageMaker, and Vertex, with different schedule-type support per orchestrator.
+- Exact schedule APIs and supported schedule types can change; verify current ZenML docs for the target stack before promising parity.
+
+---
+
+## Sensor -> external trigger pattern
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.sensor(job=my_job)
+def file_sensor():
+    if new_file_exists():
+        yield dg.RunRequest(run_key="new-file")
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+
+
+@pipeline
+def my_pipeline(file_path: str) -> None:
+    ...
+
+
+def handle_file_event(file_path: str) -> None:
+    # Migration note: event handling lives outside the pipeline.
+    my_pipeline(file_path=file_path)
+```
+
+**Key differences**:
+- The Dagster sensor becomes external eventing or trigger logic.
+- Do not translate sensors into endless waiting steps unless there is no better option.
+
+---
+
+## Asset check -> validation step
+
+### Dagster
+
+```python
+import dagster as dg
+import pandas as pd
+
+
+@dg.asset
+def customers() -> pd.DataFrame:
+    ...
+
+
+@dg.asset_check(asset=customers)
+def customers_not_empty(customers: pd.DataFrame) -> dg.AssetCheckResult:
+    return dg.AssetCheckResult(passed=not customers.empty)
+```
+
+### ZenML
+
+```python
+import pandas as pd
+from zenml import step
+
+
+@step
+def customers_not_empty(customers: pd.DataFrame) -> None:
+    if customers.empty:
+        raise ValueError("customers dataset is empty")
+```
+
+**Key differences**:
+- The validation logic is preserved.
+- The independently addressable asset-check execution model is not preserved.
+
+---
+
+## multi_asset -> multi-output step
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.multi_asset(
+    outs={
+        "features": dg.AssetOut(),
+        "labels": dg.AssetOut(),
+    }
+)
+def build_training_data():
+    return [1, 2, 3], [0, 1, 0]
+```
+
+### ZenML
+
+```python
+from typing import Annotated
+
+from zenml import step
+
+
+@step
+def build_training_data() -> tuple[
+    Annotated[list[int], "features"],
+    Annotated[list[int], "labels"],
+]:
+    return [1, 2, 3], [0, 1, 0]
+```
+
+**Key differences**:
+- This is a good fit only when both outputs are always produced together.
+- If the Dagster code relies on subsetting one output without the other, flag it.
+
+---
+
+## graph_asset -> helper steps inside a pipeline
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.op
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+
+@dg.op
+def double(values: list[int]) -> list[int]:
+    return [v * 2 for v in values]
+
+
+@dg.graph_asset
+def doubled_values() -> list[int]:
+    return double(extract())
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+
+@step
+def double(values: list[int]) -> list[int]:
+    return [v * 2 for v in values]
+
+
+@pipeline
+def doubled_values_pipeline() -> None:
+    double(extract())
+```
+
+**Key differences**:
+- Dagster's graph asset exposes one asset while hiding internal ops.
+- ZenML makes the steps explicit; the former asset identity becomes a pipeline/output naming choice.
+
+---
+
+## DynamicOutput fan-out -> dynamic pipeline or redesign
+
+### Dagster
+
+```python
+import dagster as dg
+
+
+@dg.op(out=dg.DynamicOut())
+def list_regions():
+    for region in ["eu", "us"]:
+        yield dg.DynamicOutput(region, mapping_key=region)
+
+
+@dg.op
+def process_region(region: str) -> str:
+    return region.upper()
+
+
+@dg.job
+def regional_job():
+    list_regions().map(process_region)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def list_regions() -> list[str]:
+    return ["eu", "us"]
+
+
+@step
+def process_region(region: str) -> str:
+    return region.upper()
+
+
+@pipeline(dynamic=True)
+def regional_pipeline() -> None:
+    regions = list_regions()
+    process_region.map(regions)
+```
+
+**Key differences**:
+- This is only appropriate if the target ZenML setup supports dynamic pipelines and the semantics are acceptable.
+- Current ZenML docs describe dynamic-pipeline support for `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml` orchestrators.
+- The example syntax is illustrative; verify the current dynamic-pipeline API and stack support before treating this as a drop-in migration.
+- If the original Dagster job relied on operational guarantees that the target stack cannot match, redesign instead of pretending it is equivalent.

--- a/skills/zenml-dagster-migration/skills/dagster-migration/references/concept-map.md
+++ b/skills/zenml-dagster-migration/skills/dagster-migration/references/concept-map.md
@@ -1,0 +1,113 @@
+# Dagster -> ZenML Concept Map
+
+Complete mapping of Dagster concepts to their ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (conceptual equivalent with different semantics), or **absent** (no ZenML equivalent -- needs redesign).
+
+## Table of Contents
+
+- [Core Primitives](#core-primitives)
+- [Data and IO](#data-and-io)
+- [Configuration and Resources](#configuration-and-resources)
+- [Control Flow and Execution](#control-flow-and-execution)
+- [Infrastructure and Compute](#infrastructure-and-compute)
+- [Dagster+ Features](#dagster-features)
+- [Orchestrator scheduling support](#orchestrator-scheduling-support)
+
+## Core Primitives
+
+| Dagster Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@asset` | `@step` output inside a `@pipeline` | approximate | Dagster assets are first-class data products with selection/materialization semantics. ZenML step outputs are artifacts produced during pipeline execution. Preserve compute logic, but explicitly decide pipeline boundaries first. |
+| `@multi_asset` | Multi-output `@step` | approximate | Good fit when one compute body emits multiple outputs. If the Dagster code relies on subsetting individual outputs, always flag it. |
+| `@graph_asset` | Helper steps inside a pipeline, with a terminal output artifact | approximate | Dagster exposes an asset while hiding internal ops. ZenML can model the internal steps directly, but the asset identity becomes an artifact naming convention. |
+| `@graph_multi_asset` | Helper steps plus multi-output step or multiple terminal steps | approximate | Similar to `@graph_asset`, but watch for subset execution semantics. |
+| `AssetSpec` | Artifact naming/config conventions | approximate | Useful as a naming and ownership hint, not as a runtime primitive. |
+| `AssetKey` | Artifact name, tags, or `ArtifactConfig(name=...)` | approximate | Similar identity role, but ZenML artifacts are scoped to pipeline execution rather than an always-addressable asset graph. |
+| `AssetIn` / `AssetOut` | Step inputs and outputs | approximate | Dependency intent maps cleanly, but storage/loading behavior is not separable from execution in the same way. |
+| `Definitions` | Python module assembling pipelines, steps, configs, schedules | approximate | Both are composition roots, but ZenML does not expose a single registry object with Dagster's definitions semantics. |
+| `@op` | `@step` | direct | Both wrap a unit of compute. Dagster ops often migrate more cleanly than assets because they already model execution units. |
+| `@graph` | Composition helper or `@pipeline` | approximate | A graph often becomes either a ZenML pipeline or a helper function that wires steps. |
+| `@job` | `@pipeline` | approximate | Strong fit for op/job-centric Dagster code. The mapping is nearly direct for op/job-centric Dagster code, but weaker for asset jobs because ZenML lacks asset-selection execution semantics. |
+| Asset job / `define_asset_job` | One or more ZenML pipelines | approximate | The central migration decision: a Dagster asset job may need to become multiple ZenML pipelines if users rely on selective materialization or different schedules. |
+| `AssetSelection` | Separate pipeline boundaries or explicit entry points | absent | ZenML does not have Dagster's first-class asset-selection and subset materialization model. |
+| `SourceAsset` | `ExternalArtifact` or explicit source-loading step | approximate | Both represent external data, but the lifecycle and observability model differ. |
+| Observable source asset | ExternalArtifact + validation/observation step | absent | ZenML can model checks and metadata logging, but not a first-class observable source asset concept. |
+| `DynamicOut` / `DynamicOutput` | `@pipeline(dynamic=True)` with `.map()` or explicit redesign | approximate | Possible only when the target ZenML stack supports dynamic pipelines and the semantics are acceptable. Current ZenML docs describe support for `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml`; verify current support and API details before committing to this path. |
+
+## Data and IO
+
+| Dagster Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `IOManager` | Artifact store + materializer + explicit source/sink step | approximate | Dagster IO managers can control both write and downstream load behavior. ZenML materializers primarily handle serialization/deserialization for artifacts; business logic around loading external systems usually belongs in steps. |
+| `ConfigurableIOManager` | Materializer plus config/secrets/service connector wiring | approximate | Similar intent, but split across multiple ZenML primitives. |
+| `FilesystemIOManager`, `mem_io_manager`, custom storage IO | Artifact store configuration or explicit storage step | approximate | File-based serialization often maps well; in-memory semantics and custom lazy-loading behavior do not, and should be flagged when they matter. |
+| Materialization event | Artifact creation + metadata logging | approximate | ZenML artifacts are created automatically when a step returns a value. |
+| Observation event | `log_metadata()` or validation step | approximate | Capture observations explicitly in a step; no first-class Dagster observation event. |
+| Asset checks | Validation step consuming the artifact | approximate | Preserve the check logic, but the independently selectable asset-check execution model is absent. |
+| Dagster types | Python type hints + materializers | approximate | ZenML type annotations drive materializer selection rather than Dagster runtime type checks. |
+| Asset metadata | Artifact metadata/tags | approximate | Similar idea, different lifecycle and UI surfaces. |
+
+## Configuration and Resources
+
+| Dagster Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Config` / Pydantic config | Pipeline parameters + YAML config | approximate | Similar validation intent, but ZenML passes typed Python values into steps/pipelines. |
+| `RunConfig` | Pipeline invocation args / run configuration | approximate | Runtime values still exist, but the API and override semantics differ. |
+| `EnvVar` | ZenML secrets or environment variables | approximate | Same purpose, different management surface. |
+| `ConfigurableResource` | Step-local client object, ZenML secret, service connector, or stack component | approximate | Treat this as an intent-mapping exercise: infrastructure-wide concerns go to the stack; request-scoped clients can stay local to steps. |
+| Resource dependency injection | Step helper construction or explicit function arguments | approximate | ZenML does not have the same resource injection system, so dependencies become explicit Python objects or stack-backed integrations. |
+
+## Control Flow and Execution
+
+| Dagster Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Asset dependency graph | Step invocation order with artifact wiring | approximate | Compute order can be preserved, but asset identity and partial-materialization semantics change. |
+| Partition definitions (`DailyPartitionsDefinition`, etc.) | Pipeline parameters plus schedule/trigger discipline | approximate | Preserve the partition key as an explicit parameter; partition-aware orchestration semantics are not first-class in ZenML. |
+| Partition mappings | Custom parameter plumbing or redesign | absent | No native equivalent for cross-partition dependency semantics. |
+| Backfills | Repeated pipeline runs driven externally | approximate | Feasible, but operational behavior lives in triggering logic rather than as a Dagster-native backfill primitive. |
+| Schedules | `Schedule(...)` on supported orchestrators | approximate | ZenML delegates schedules to the orchestrator rather than owning a scheduler itself. |
+| Sensors | External trigger or polling step | absent | No sensor primitive, no cursor semantics, no lightweight deferral. |
+| Asset sensors | External trigger or observation step plus trigger service | absent | Same issue as sensors, with extra asset-graph semantics missing. |
+| Declarative Automation / auto-materialize policies | External automation logic + triggers | absent | The policy engine has no direct ZenML equivalent. Always flag. |
+| Freshness policies | Explicit SLA/monitoring logic | absent | Can be approximated with schedules plus checks, but not as a first-class orchestration policy. |
+| Asset reconciliation | Manual pipeline decomposition + trigger logic | absent | Requires redesign around pipeline boundaries and external automation. |
+| Conditional branching based on runtime values | Dynamic pipeline or redesign | approximate | Only viable if dynamic pipelines are available and the branching semantics are acceptable. |
+| Retry policy (`RetryPolicy`) | `StepRetryConfig` | direct | Retry intent maps cleanly. |
+| Hooks / run-status monitoring | Step hooks, metadata logging, external monitoring | approximate | Useful for notifications and observability, but the operational surfaces differ. |
+
+## Infrastructure and Compute
+
+| Dagster Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Executor / launcher config | Orchestrator + step operator configuration | approximate | Same high-level concern, different APIs and abstractions. |
+| Container resources / executor tags | `ResourceSettings` / `DockerSettings` | approximate | Preserve intent, not the exact runtime contract. |
+| Docker executor / k8s run launcher | Containerized orchestrator or step operator | approximate | ZenML is Python-first and container-oriented, but the specific execution details differ. |
+| Code location / workspace | Python project / code repository integration | approximate | Move Dagster repository structure into importable Python modules for ZenML. |
+| Multi-code-location deployments | Multiple repos/modules or multiple pipelines | approximate | Supported operationally, but not with Dagster's same workspace model. |
+
+## Dagster+ Features
+
+| Dagster+ Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Hosted deployment / control plane | ZenML server / ZenML Pro | approximate | Both offer central control planes, but features and operational assumptions differ. |
+| Alerting | Alerters, hooks, external monitoring | approximate | Comparable outcome, different configuration model. |
+| Asset health and observability views | Artifact lineage, metadata, dashboards | approximate | ZenML is artifact/run-centric rather than asset-centric. |
+| Branch deployments / branch environments | Separate stacks, workspaces, or code branches | approximate | Similar operational intent, different product surface. |
+
+## Orchestrator scheduling support
+
+ZenML scheduling support is orchestrator-dependent. Verify the target orchestrator before migrating any Dagster schedule-heavy project. Treat the table below as a planning aid, not a permanent guarantee of current support.
+
+| Orchestrator | Scheduling | Types Supported |
+|---|:---:|---|
+| Airflow | Yes | Cron, Interval |
+| AzureML | Yes | Cron, Interval |
+| Databricks | Yes | Cron only |
+| HyperAI | Yes | Cron, One-time |
+| Kubeflow | Yes | Cron, Interval |
+| Kubernetes | Yes | Cron only |
+| Local | No | N/A |
+| LocalDocker | No | N/A |
+| SageMaker | Yes | Cron, Interval, One-time |
+| SkyPilot | No | N/A |
+| Tekton | No | N/A |
+| Vertex | Yes | Cron only |

--- a/skills/zenml-dagster-migration/skills/dagster-migration/references/gaps-and-flags.md
+++ b/skills/zenml-dagster-migration/skills/dagster-migration/references/gaps-and-flags.md
@@ -1,0 +1,249 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the Dagster patterns that are most dangerous to silently approximate during migration -- the places where Dagster and ZenML behave fundamentally differently, and where a naive translation changes the pipeline's actual behavior.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Dagster Equivalent](#zenml-features-with-no-dagster-equivalent)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### Asset selection and partial materialization
+
+**What Dagster does**: Dagster treats assets as first-class addressable nodes. Users can materialize a subset of an asset graph, re-materialize one downstream asset while loading upstream assets from storage, or define jobs around subsets.
+
+**Why it matters**: This is the biggest semantic mismatch in a Dagster -> ZenML migration. ZenML runs pipelines, not selected asset subsets.
+
+**ZenML gap**: No first-class asset selection or partial materialization model.
+
+**Redesign approaches**:
+- Split the Dagster graph into multiple ZenML pipelines that match real operational boundaries.
+- Use explicit source-loading steps or `ExternalArtifact` when a downstream pipeline needs previously produced data.
+- Add a pipeline-boundary section to the migration report explaining what was split and why.
+
+### Partitions, partition mappings, and backfills
+
+**What Dagster does**: Partitions are built into asset definitions and jobs. Dagster can reason about partition keys, upstream/downstream partition mappings, and backfill ranges.
+
+**Why it matters**: Partition-aware orchestration changes both execution and correctness. A naive translation to a single `run_date` parameter often drops important semantics.
+
+**ZenML gap**: No first-class partition graph or partition-mapping engine.
+
+**Redesign approaches**:
+- Model the partition key explicitly as a pipeline parameter.
+- Move backfill orchestration into external triggering logic or batch job wrappers.
+- If the Dagster code depends on non-trivial partition mappings, classify it as HIGH severity and require a custom redesign.
+
+### Declarative Automation / freshness policies / auto-materialize behavior
+
+**What Dagster does**: Dagster can declaratively describe when assets should be materialized or considered stale, and can automate asset runs from those policies.
+
+**Why it matters**: These policies are not just schedules; they are data-aware orchestration rules.
+
+**ZenML gap**: No equivalent policy engine in OSS ZenML.
+
+**Redesign approaches**:
+- Re-express the intent as schedules, monitoring checks, and external triggers.
+- Document what signal was lost (freshness deadline, dependency-aware automation, etc.).
+- Keep the decision explicit in the migration report; do not quietly downgrade policy-driven automation to a plain cron job.
+
+### Sensors and asset sensors
+
+**What Dagster does**: Sensors poll external systems or Dagster state and emit runs, often with cursor semantics to avoid duplicate work.
+
+**Why it matters**: Sensors encode event-driven orchestration and stateful polling logic.
+
+**ZenML gap**: No sensor primitive, no cursor API, no lightweight deferral loop.
+
+**Redesign approaches**:
+- Use external eventing (webhooks, queues, cloud events) to trigger pipeline runs.
+- If polling must remain, implement a polling service outside the ZenML pipeline or a polling step with strict timeout/resource notes.
+- Treat sensor cursor behavior as a migration concern, not an implementation detail.
+
+### IO managers with business logic
+
+**What Dagster does**: IO managers can decide how outputs are written and how downstream consumers load them. In many codebases, they also embed warehouse/table conventions, lazy loading, or environment-specific routing.
+
+**Why it matters**: If you translate a smart IO manager to a plain ZenML materializer, you often preserve serialization but lose the real data-access behavior.
+
+**ZenML gap**: Materializers are not a drop-in replacement for arbitrary IO-manager behavior.
+
+**Redesign approaches**:
+- Keep serialization concerns in materializers.
+- Move external read/write behavior into explicit source/sink steps.
+- Flag any IO manager that does more than file/object serialization.
+
+### Multi-asset subset semantics
+
+**What Dagster does**: `@multi_asset` can expose several assets from one compute body, and some setups rely on selectively materializing only a subset.
+
+**Why it matters**: A multi-output ZenML step can preserve the compute body, but not the independently materializable asset-subset semantics.
+
+**ZenML gap**: No first-class subset selection for step outputs.
+
+**Redesign approaches**:
+- If all outputs are always produced together, a multi-output step is fine.
+- If the code relies on subset execution, split the compute body or flag it as unsupported.
+
+### Asset checks as independently managed graph nodes
+
+**What Dagster does**: Asset checks are first-class checks attached to assets, can be executed independently, and participate in the asset graph view.
+
+**Why it matters**: Validation remains important after migration, but the operational model changes.
+
+**ZenML gap**: Checks are best represented as validation steps or metadata logging, not as independently selectable asset-graph nodes.
+
+**Redesign approaches**:
+- Translate the check logic into a validation step.
+- Log the result as metadata and fail the step when appropriate.
+- Flag any workflow that depends on independently running the checks outside the compute path.
+
+### Observable source assets
+
+**What Dagster does**: Dagster can observe external sources and attach metadata/freshness information to them as graph nodes.
+
+**Why it matters**: This mixes data observability with orchestration.
+
+**ZenML gap**: No first-class observable-source abstraction.
+
+**Redesign approaches**:
+- Model the external source as an `ExternalArtifact` or explicit ingestion step.
+- Add a validation/observation step for metadata collection.
+- Document the loss of asset-graph observability semantics.
+
+---
+
+## Behavioral Differences
+
+These are the semantic differences that are safe to translate but important to communicate to the user.
+
+### Asset materialization vs pipeline runs
+
+| Aspect | Dagster | ZenML |
+|---|---|---|
+| **Primary execution unit** | Asset or job materialization | Pipeline run |
+| **Addressability** | Individual assets and asset subsets | Entire pipeline entry point |
+| **Re-use of upstream results** | Load upstream asset from storage without recompute | Use previously stored artifact via explicit source/loading pattern |
+| **Primary mental model** | Data products in an asset graph | Typed compute steps in a pipeline DAG |
+
+**Practical impact**: The same compute logic may migrate cleanly while the operational boundary changes dramatically. Always explain where a former Dagster graph was split into multiple ZenML pipelines.
+
+### IO managers vs materializers + artifact store
+
+| Aspect | Dagster IOManager | ZenML Materializer + Artifact Store |
+|---|---|---|
+| **Responsibility** | Store outputs and load downstream inputs | Serialize and load artifacts stored by ZenML |
+| **External system reads** | Often embedded in the IO manager | Usually explicit step logic |
+| **Control over downstream loading** | First-class | Limited to artifact materialization |
+| **Good fit for business logic** | Common but risky | Better moved into explicit steps |
+
+**Practical impact**: If a Dagster IO manager hides warehouse/table loading conventions, preserve that logic explicitly rather than assuming a custom materializer is sufficient.
+
+### Resources vs stack components / connectors / secrets
+
+| Aspect | Dagster | ZenML |
+|---|---|---|
+| **Injection model** | Resource dependency injection | Stack components, service connectors, secrets, or local helper construction |
+| **Scope** | Often both infra-wide and per-call | Split by responsibility |
+| **Best migration strategy** | Map by intent | Ask: is this infra, auth, or plain Python helper code? |
+
+**Practical impact**: Treat each `ConfigurableResource` like a suitcase you unpack: credentials go one place, cluster settings another, and request-specific helper logic stays in code.
+
+### Partition-aware execution vs parameterized runs
+
+| Aspect | Dagster | ZenML |
+|---|---|---|
+| **Partition key** | First-class orchestration concept | Explicit pipeline parameter |
+| **Partition mappings** | Built-in dependency reasoning | Manual plumbing or redesign |
+| **Backfills** | First-class operational workflow | Series of triggered pipeline runs |
+
+**Practical impact**: Passing `run_date` preserves only the label, not the whole partition engine.
+
+### Scheduling and automation
+
+| Aspect | Dagster | ZenML |
+|---|---|---|
+| **Scheduler ownership** | Dagster automation/schedules/sensors | Orchestrator-backed schedules and external triggers |
+| **Data-aware policies** | Freshness + declarative automation | Must be rebuilt explicitly |
+| **Event-driven triggers** | Sensors / asset sensors | External eventing or custom trigger service |
+
+**Practical impact**: A plain cron schedule may preserve timing but not the original automation logic.
+
+### Testing model
+
+| Aspect | Dagster | ZenML |
+|---|---|---|
+| **Focus** | Asset/op/job definitions and Dagster execution helpers | Plain Python unit tests plus pipeline/step execution |
+| **Graph object testing** | Common | Less central |
+| **Migration implication** | Refactor tests toward Python function behavior and Dagster execution helpers | Refactor tests toward Python function behavior and artifact expectations |
+
+---
+
+## Migration Decision Tree
+
+Use this to systematically classify a Dagster codebase before generating ZenML code.
+
+```
+1) Classify the source model
+   ├── Mostly assets -> "asset_graph"
+   ├── Mostly ops/graphs/jobs -> "op_job"
+   └── Mixed -> inventory both before translating anything
+
+2) Find the true run boundaries
+   ├── Single tightly coupled job/subgraph -> candidate single ZenML pipeline
+   ├── Asset groups with different schedules or selective materialization -> split into multiple pipelines
+   └── Heavy unsupported semantics -> partial migration + redesign report
+
+3) Classify compute nodes
+   ├── @op -> translate directly to @step
+   ├── @asset -> extract compute body into @step, preserve outputs as artifacts
+   ├── @multi_asset -> multi-output step IF subset semantics not required
+   ├── @graph_asset -> helper steps + terminal output artifact
+   └── DynamicOutput -> dynamic pipeline or redesign
+
+4) Classify storage and IO
+   ├── Simple serialization IO manager -> materializer/artifact store mapping
+   ├── IO manager with warehouse/file loading logic -> explicit source/sink steps
+   └── mem-only or lazy-load semantics -> HIGH severity flag
+
+5) Classify config and resources
+   ├── Typed config -> pipeline params / YAML config
+   ├── Credentials -> ZenML secrets or service connectors
+   ├── Infra-wide clients -> stack components / orchestrator settings
+   └── Per-step helper objects -> construct in code
+
+6) Classify orchestration features
+   ├── Simple schedule only -> Schedule(...) if target orchestrator supports it
+   ├── Sensors / asset sensors -> FLAG HIGH, redesign to external trigger
+   ├── Declarative automation / freshness -> FLAG HIGH, redesign to policy + trigger system
+   ├── Partitions/backfills -> preserve partition key explicitly, flag non-trivial mappings
+   └── Asset checks -> validation steps with metadata logging
+
+7) Decide the migration result
+   ├── No HIGH flags -> full migration with caveats documented
+   ├── Some HIGH flags but compute mostly portable -> partial translation + TODOs + redesign guidance
+   └── Unsupported semantics dominate -> stop after migration plan/report and explain why full auto-migration would be misleading
+```
+
+---
+
+## ZenML Features with No Dagster Equivalent
+
+These are capabilities the user gains after migration. Include relevant ones in the "What You Get for Free" section of the migration report.
+
+| ZenML Feature | Value |
+|---|---|
+| **Artifact versioning and lineage** | Every step output is versioned and connected to the code and inputs that produced it. |
+| **Step caching** | Steps can skip re-execution when code and inputs have not changed. |
+| **Stack abstraction** | The same pipeline code can run on different stacks without rewriting the business logic. |
+| **Service connectors** | Unified authentication abstraction across cloud providers and stack components. |
+| **Pipeline deployments / external triggering patterns** | Strong patterns for API- or service-driven execution, especially when replacing sensors with external triggers. |
+| **Model Control Plane** | First-class ML model tracking, promotion, and cross-pipeline lineage. |
+| **Artifact-centric metadata and visualizations** | Useful when migrating data/ML workflows that need better run-to-artifact traceability. |

--- a/skills/zenml-databricks-migration/skills/databricks-migration/references/concept-map.md
+++ b/skills/zenml-databricks-migration/skills/databricks-migration/references/concept-map.md
@@ -56,17 +56,23 @@ Complete mapping of Databricks Workflows (Lakeflow Jobs) concepts to their ZenML
 
 Not all ZenML orchestrators support scheduling. Check this before migrating scheduled jobs:
 
-| Orchestrator | Scheduling | Types Supported |
-|---|:---:|---|
-| Kubernetes | Yes | Cron |
-| Vertex AI | Yes | Cron |
-| SageMaker | Yes | Cron, Interval, One-time |
-| AzureML | Yes | Cron, Interval |
-| Airflow (as ZenML orchestrator) | Yes | Cron, Interval |
-| Kubeflow | Yes | Cron, Interval |
-| Databricks | Yes | Cron only |
-| Local / LocalDocker | No | -- |
-| SkyPilot | No | -- |
+| Orchestrator | Scheduling Support | Supported Schedule Types | Native Schedule Management |
+|---|:---:|---|:---:|
+| AirflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| AzureMLOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| DatabricksOrchestrator | ✅ | Cron only | ⛔️ |
+| HyperAIOrchestrator | ✅ | Cron, One-time | ⛔️ |
+| KubeflowOrchestrator | ✅ | Cron, Interval | ⛔️ |
+| KubernetesOrchestrator | ✅ | Cron only | ✅ |
+| LocalOrchestrator | ⛔️ | N/A | N/A |
+| LocalDockerOrchestrator | ⛔️ | N/A | N/A |
+| SagemakerOrchestrator | ✅ | Cron, Interval, One-time | ⛔️ |
+| SkypilotAWSOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotAzureOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotGCPOrchestrator | ⛔️ | N/A | N/A |
+| SkypilotLambdaOrchestrator | ⛔️ | N/A | N/A |
+| TektonOrchestrator | ⛔️ | N/A | N/A |
+| VertexOrchestrator | ✅ | Cron only | ⛔️ |
 
 ## Data Passing and Parameters
 

--- a/skills/zenml-flyte-migration/plugin.json
+++ b/skills/zenml-flyte-migration/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "zenml-flyte-migration",
+  "version": "1.0.0",
+  "description": "Migrate Flyte workflows, tasks, and LaunchPlans to idiomatic ZenML pipelines with concept mapping, code translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "flyte",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration",
+    "workflows",
+    "launchplans"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-flyte-migration/skills/flyte-migration/SKILL.md
+++ b/skills/zenml-flyte-migration/skills/flyte-migration/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: flyte-to-zenml-migration
+description: >-
+  Migrate Flyte workflows, tasks, LaunchPlans, and Flytekit code to idiomatic
+  ZenML pipelines. Handles concept mapping (`@task`->`@step`,
+  `@workflow`->`@pipeline`, `map_task()`->dynamic `.map()`,
+  `conditional()`->dynamic branching, `LaunchPlan`->schedule/config split),
+  code translation, special-type migration (`FlyteFile`, `FlyteDirectory`,
+  `StructuredDataset`, `FlyteSchema`), Docker/image mapping, and flags
+  unsupported patterns (`@eager`, `ContainerTask`, reference entities,
+  checkpointing, interruptible semantics) for human review. Use this skill
+  whenever the user mentions Flyte migration, converting Flyte to ZenML,
+  porting Flyte workflows, replacing Flyte with ZenML, or asks how a Flyte
+  concept maps to ZenML -- even if they do not explicitly say "migrate". Also
+  use when they paste Flytekit code and ask to make it work with ZenML, or when
+  they describe a workflow using Flyte terminology (`@dynamic`, `LaunchPlan`,
+  `map_task`, `conditional`, `ImageSpec`, `FlyteFile`, `StructuredDataset`,
+  `reference_task`, `reference_workflow`) in a ZenML context. If the user just
+  asks a quick conceptual question ("what is the ZenML equivalent of
+  LaunchPlan?" or "how should FlyteFile map?"), answer it directly from the
+  concept map -- no need to run the full migration workflow.
+---
+
+# Migrate Flyte to ZenML
+
+This skill translates Flyte workflows into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing Flytekit code, classifying each concept, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project with a migration report.
+
+## How migration works at a high level
+
+Flyte and ZenML are closer to each other than Flyte and older scheduler-first systems like Airflow. Both are Python-first orchestration frameworks that care about typed execution units, retries, scheduling, and containerized execution. So the migration is often more like “rewire the execution story” than “translate operator objects into functions.”
+
+But there are still sharp edges. Flyte has a richer workflow transport type system (`FlyteFile`, `StructuredDataset`, `FlyteSchema`), a stronger registered execution surface via `LaunchPlan`, and special execution features like `@dynamic`, `@eager`, `map_task()`, `conditional()`, `ContainerTask`, and reference entities. ZenML can often reach the same business outcome, but not always with the same runtime semantics.
+
+This means migration is not a decorator-swap exercise. Some patterns translate directly, some need approximation, and some require honest redesign.
+
+### The three mapping types
+
+Every Flyte concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in the migration report |
+| **Absent** | No safe ZenML core equivalent | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Flyte Code
+
+Ask the user for the Flyte source before doing anything else. The ideal input set is:
+
+- Flyte task and workflow Python files
+- `LaunchPlan` definitions
+- `ImageSpec` or other container/image configuration
+- plugin-backed task config modules (`task_config=...`, plugin resources, external job specs)
+- any custom types, materializers, or serializers
+- any Union-specific code if present
+
+Read everything thoroughly. For each workflow, identify:
+
+1. **Execution units** -- plain `@task`, `@workflow`, nested workflows, subworkflows
+2. **Type system** -- primitives, collections, dataclasses, Pydantic models, `FlyteFile`, `FlyteDirectory`, `StructuredDataset`, `FlyteSchema`
+3. **Control flow** -- `@dynamic`, `map_task()`, `conditional()`, `@eager`
+4. **Execution metadata** -- retries, `cache=True`, `cache_version`, `timeout`, `interruptible=True`
+5. **Infrastructure** -- `Resources`, `ImageSpec`, per-task images, `ContainerTask`, plugin `task_config`
+6. **Scheduling and trigger surface** -- `LaunchPlan`, `default_inputs`, `fixed_inputs`, schedules, notifications
+7. **Cross-project boundaries** -- `reference_task`, `reference_workflow`, `reference_launch_plan`
+8. **Advanced recovery/reporting** -- checkpointing, Decks, custom HTML/report artifacts
+9. **Union-only extensions** -- Actors, reusable containers, Union Artifacts, Union Channels, commercial control-plane features
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it as direct, approximate, or absent. Use the quick guide below and the full mapping tables in [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+Use **direct** sparingly. In Flyte migrations, many things are mechanically easy to rewrite but still semantically different enough that they belong in the **approximate** bucket.
+
+**Usually straightforward translations (often still classified as approximate):**
+- plain `@task` -> `@step`
+- plain `@workflow` -> `@pipeline`
+- primitive/container types where ZenML built-in materializers are enough
+- basic retries -> `StepRetryConfig`
+- simple resource hints -> `ResourceSettings`
+
+**Approximate translations (translate with caveats):**
+- `@dynamic` -> `@pipeline(dynamic=True)`
+- `map_task()` -> `.map()` inside a dynamic pipeline
+- `conditional()` -> dynamic pipeline branching with `.load()`
+- `StructuredDataset` / `FlyteSchema` -> dataframe or table artifact
+- `FlyteFile` / `FlyteDirectory` -> `Path` artifact or wrapper type + materializer
+- `ImageSpec` / per-task image settings -> `DockerSettings`
+- basic `LaunchPlan` scheduling/defaults -> pipeline defaults + `Schedule`
+- notifications -> hooks / alerters / external alerts
+- Decks -> metadata logging, visualizers, or explicit report artifacts
+
+When in doubt, classify Flyte decorator-level concepts as **approximate** and explain the runtime difference in the migration report.
+
+**Absent / needs redesign (flag for human review):**
+- `@eager`
+- `ContainerTask`
+- `reference_task`, `reference_workflow`, `reference_launch_plan`
+- `interruptible=True`
+- portable timeout parity
+- intra-task checkpointing
+- `map_task(min_success_ratio=...)`
+- Union Actors / reusable container semantics
+- Union Artifacts / Union Channels when semantics are unclear
+
+#### Present the migration plan
+
+Before writing code, present a concrete summary:
+
+> "Here's what I found in your Flyte code:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with noted caveats): [list]
+> - **Needs redesign** (cannot auto-migrate safely): [list with brief explanation]
+>
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain them in story form: what the Flyte code was relying on, what ZenML does differently, and what redesign is safest.
+
+### Phase 3: Generate ZenML Code
+
+Translate the Flyte workflow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── transform.py
+│   └── load.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Only when special Flyte types need them
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+This matches the `zenml-pipeline-authoring` skill's conventions. Key rules:
+- one step per file in `steps/`
+- separate pipeline definition from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` uses `zenml>=0.94.1` and `requires-python = ">=3.12"`
+- always generate `configs/dev.yaml` and `configs/prod.yaml`
+- always generate `README.md` explaining the migrated pipeline and what still needs human review
+- run `zenml init` at project root
+
+#### Translation rules
+
+See [references/code-patterns.md](references/code-patterns.md) for detailed side-by-side examples. The core rules are:
+
+- `@task` -> `@step`
+- `@workflow` -> `@pipeline`
+- `@dynamic` -> `@pipeline(dynamic=True)`
+- `map_task()` -> `.map()` only inside dynamic pipelines
+- `conditional()` -> `.load()`-driven branching in dynamic pipelines
+- `Resources(...)` -> `ResourceSettings(...)`
+- `ImageSpec(...)` -> `DockerSettings(...)`
+- `retries=N` -> `StepRetryConfig(max_retries=N, ...)`
+- LaunchPlan schedule -> `Schedule(...)`
+- LaunchPlan defaults/fixed inputs -> explicit pipeline defaults, wrapper pipeline, or deployment-specific config
+- LaunchPlan notifications -> hooks / alerter hooks
+
+#### How to treat Flyte special types
+
+These choices should be deliberate, not improvised:
+
+**`FlyteFile` / `FlyteDirectory`**
+- Default target: `Path` artifact
+- If the original code depended on remote URI, provenance, or lazy localization semantics, do **not** flatten it to `str`
+- Use a wrapper type + custom materializer, or preserve the missing semantics as artifact metadata
+
+**`StructuredDataset` / `FlyteSchema`**
+- Default target: `pd.DataFrame`, `polars.DataFrame`, or `pyarrow.Table`
+- Match the concrete data shape the code actually uses
+- If schema, format, or backend metadata mattered in Flyte, preserve it with:
+  - a validator step
+  - explicit metadata logging
+  - or a custom materializer
+
+**Externally managed data**
+- If the Flyte workflow consumed data that was not produced inside the current run, prefer `register_artifact` / `ExternalArtifact`
+- Do not pretend an external file was created by a ZenML step just to make the code look tidy
+
+**Exotic Python objects**
+- A custom materializer is the preferred destination
+- `CloudpickleMaterializer` can be a temporary unblocker, but never present it as the intended long-term production state
+
+#### Code comment style
+
+Keep migration comments brief and useful:
+
+- use `# Migration note:` for short caveats
+- use `# TODO(migration):` for items requiring user action
+- put detailed reasoning in `MIGRATION_REPORT.md`, not in large inline comments
+
+#### Handling approximate translations
+
+When translating an approximate pattern, add a short inline note that explains the semantic difference:
+
+```python
+@step
+def read_remote_input(path: Path) -> pd.DataFrame:
+    # Migration note: the original Flyte workflow used StructuredDataset
+    # metadata to control reader behavior. This ZenML step now assumes the
+    # artifact is a pandas DataFrame and validates the expected columns here.
+    ...
+```
+
+#### Handling absent patterns
+
+For patterns with no safe ZenML equivalent:
+
+1. add a clearly marked `# TODO(migration)` comment
+2. include the item in the migration report
+3. suggest a redesign approach instead of silently approximating
+
+```python
+# TODO(migration): UNSUPPORTED -- Flyte ContainerTask with file-based IO
+# contract. ZenML has no first-class raw container task primitive here.
+# Redesign this as a wrapper step that submits the external job and stages IO
+# explicitly, or replace it with a custom step operator.
+@step
+def run_external_job(...) -> None:
+    ...
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root. Use this structure:
+
+```markdown
+# Migration Report: [workflow] -> [pipeline]
+
+## Summary
+- **Source workflow**: `[workflow_name]`
+- **Target pipeline**: `[pipeline_name]`
+- **Tasks migrated**: X direct, Y approximate, Z flagged
+- **LaunchPlans reviewed**: N
+- **Plugin-backed tasks reviewed**: M
+
+## Direct Translations
+| Flyte Concept | ZenML Target | Notes |
+
+## Approximate Translations
+| Flyte Concept | ZenML Target | What Changed |
+
+## Flagged for Review
+| Flyte Pattern | Severity | Issue | Suggested Redesign |
+
+## Type and Artifact Mapping
+| Flyte type/pattern | ZenML representation | Notes |
+
+## Scheduling and LaunchPlan Mapping
+
+## Infrastructure and Containerization Mapping
+
+## Limitations and Key Differences
+
+## What's NOT Migrated
+
+## What You Get for Free After Migration
+
+## Recommended Next Steps
+```
+
+In the report, put **Limitations and Key Differences** before **What You Get for Free After Migration** so the user sees the caveats first.
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a "Recommended Next Steps" section in the report AND communicate it to the user.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+Always suggest this first:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerts, and other production-readiness features."
+
+#### 2. Documentation links for flagged patterns
+
+For every flagged pattern, include the relevant ZenML docs. Common Flyte-migration links:
+
+- Dynamic pipelines: `https://docs.zenml.io/how-to/steps-pipelines/dynamic-pipelines`
+- Scheduling: `https://docs.zenml.io/how-to/steps-pipelines/schedule-a-pipeline`
+- Orchestrators: `https://docs.zenml.io/stacks/stack-components/orchestrators`
+- Containerization: `https://docs.zenml.io/how-to/containerization/containerization`
+- Service connectors / auth: `https://docs.zenml.io/how-to/infrastructure-deployment/auth-management`
+- Materializers: `https://docs.zenml.io/concepts/artifacts/materializers`
+- Deployment: `https://docs.zenml.io/how-to/deployment/deployment`
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML docs while you finish the migration, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Community support for unsupported patterns
+
+When there are **2+ HIGH-severity flags**, generate a copy-paste Slack message for `zenml.io/slack` that includes:
+- what is being migrated
+- the unsupported Flyte patterns
+- a short code snippet for each
+- the proposed workaround
+- a clear ask for better patterns or upcoming support
+
+```markdown
+**Flyte -> ZenML Migration Help**
+
+I'm migrating a Flyte workflow (`[workflow_name]`) that uses [patterns]. The migration skill flagged these as needing redesign:
+
+1. **[Pattern]**: [brief description + code snippet]
+   - Suggested workaround: [X]
+   - Why this matters: [what changes without a proper solution]
+
+2. **[Pattern]**: [brief description + code snippet]
+   - Suggested workaround: [Y]
+
+I've implemented the workarounds above, but I'm wondering if there's a better approach, an upcoming feature, or a pattern I'm missing.
+```
+
+#### 5. Open GitHub issues for genuine feature gaps
+
+When the migration reveals a real capability gap in ZenML, offer to open a GitHub issue on `zenml-io/zenml` using `gh issue create`.
+
+#### 6. Run `/simplify`
+
+After migration is complete, always suggest running `/simplify` on the generated code. Migration often leaves temporary comments, repeated wrappers, and verbose explanations that should be cleaned up.
+
+#### 7. Use `zenml-pipeline-authoring` for deeper customization
+
+Recommend `zenml-pipeline-authoring` for:
+- Docker settings for remote execution
+- YAML configuration for multiple environments
+- custom materializers for Flyte-like special types
+- deployment and serving patterns
+
+## Important Behavioral Differences to Communicate
+
+Always mention the relevant ones in the migration report.
+
+### Flyte transport types != ZenML artifacts
+
+Flyte's special types are part of the transport layer. ZenML relies on Python types plus materializers. That changes:
+- **file semantics** -- `FlyteFile` / `FlyteDirectory` often need more than a plain string path
+- **tabular semantics** -- `StructuredDataset` and `FlyteSchema` may carry metadata that has to be recreated intentionally
+- **serialization** -- ZenML makes the materialization strategy explicit
+- **external data** -- `ExternalArtifact` / `register_artifact` are often the cleanest migration target
+
+### Dynamic execution semantics
+
+Flyte dynamic features are runtime engine features. ZenML dynamic pipelines load values back into Python to shape the graph. That means:
+- `@dynamic` is only an approximate match
+- `map_task()` and `.map()` are similar in goal but not identical in backend semantics
+- `conditional()` must be treated carefully when it depends on runtime values
+
+### LaunchPlan != Schedule
+
+`LaunchPlan` is not just Flyte's cron object. It is also the registered execution surface with defaults, fixed inputs, and notifications. ZenML's `Schedule` only covers the scheduling slice. The rest has to be made explicit with pipeline defaults, config, deployments, or wrapper pipelines.
+
+### Infrastructure differences
+
+Flyte makes raw container execution and plugin-backed task contracts first-class. ZenML is stronger at portable Python pipelines plus stack abstractions. This means:
+- `ImageSpec` and `DockerSettings` are close in spirit, not identical in lifecycle
+- `ContainerTask` is a redesign boundary
+- retries map better than timeouts or interruptible semantics
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Translating `FlyteFile` to `str` | Loses artifact semantics and remote/localization behavior | Use `Path`, plus metadata or a wrapper type if URI semantics matter |
+| Translating `StructuredDataset` to `Any` | Destroys the tabular contract and hides schema drift | Use explicit dataframe/table types |
+| Replacing `map_task()` with a plain Python loop in a static pipeline | Removes parallel semantics and per-item behavior | Use a dynamic pipeline with `.map()` or redesign |
+| Replacing `conditional()` with plain `if` in a non-dynamic pipeline | Breaks runtime branch semantics | Use `@pipeline(dynamic=True)` or move the decision into a step |
+| Mapping `LaunchPlan` to only `Schedule` | Loses fixed inputs, defaults, notifications, and trigger identity | Split it into config, wrapper pipelines, deployments, and schedules |
+| Treating `interruptible=True` as "just add retries" | Spot/preemptible behavior is not the same as retry behavior | Move spot handling to the target backend config |
+| Rewriting `ContainerTask` as a normal Python step without reviewing IO protocol | Changes the execution contract completely | Wrap the external job or build a custom operator |
+| Ending the migration on `CloudpickleMaterializer` | It is a temporary escape hatch, not a stable design | Create proper materializers or simplify the data contract |
+| Mirroring Flyte plugin config fields 1:1 | Plugin semantics do not carry over automatically | Migrate the business outcome, not the config object |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- Full concept mapping tables for Flyte concepts, special types, LaunchPlans, plugins, and Union features
+- [references/code-patterns.md](references/code-patterns.md) -- Side-by-side Flyte -> ZenML code translations for workflows, dynamic execution, special types, LaunchPlans, image settings, retries, and raw container patterns
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- Must-flag patterns, behavioral differences, migration decision tree, and the full list of "do not silently approximate" patterns
+
+### ZenML documentation
+
+For topics beyond migration (stack setup, artifact handling, deployment, productionization), query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-flyte-migration/skills/flyte-migration/references/code-patterns.md
+++ b/skills/zenml-flyte-migration/skills/flyte-migration/references/code-patterns.md
@@ -1,0 +1,520 @@
+# Code Translation Patterns
+
+Side-by-side Flyte → ZenML translations for the patterns most likely to appear in a real migration. Treat these as migration templates, not proof of semantic identity.
+
+ZenML pipelines often materialize important outputs as step artifacts instead of mirroring a Flyte workflow's explicit return value. That is why several ZenML examples below use a `None`-returning pipeline while still preserving the real data flow through step outputs.
+
+## Table of Contents
+
+- [Simple Task/Workflow](#simple-taskworkflow)
+- [Dynamic Workflow (`@dynamic`)](#dynamic-workflow-dynamic)
+- [Eager Workflow (`@eager`)](#eager-workflow-eager)
+- [`map_task()`](#map_task)
+- [`conditional()`](#conditional)
+- [FlyteFile and FlyteDirectory](#flytefile-and-flytedirectory)
+- [StructuredDataset](#structureddataset)
+- [ImageSpec and Per-Task Containers](#imagespec-and-per-task-containers)
+- [Resources and GPU Requests](#resources-and-gpu-requests)
+- [Caching with `cache_version`](#caching-with-cache_version)
+- [Retries and Timeouts](#retries-and-timeouts)
+- [LaunchPlans and Scheduling](#launchplans-and-scheduling)
+- [Raw `ContainerTask`](#raw-containertask)
+
+## Simple Task/Workflow
+
+### Flyte
+
+```python
+from flytekit import task, workflow
+
+@task
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+@task
+def total(values: list[int]) -> int:
+    return sum(values)
+
+@workflow
+def simple_workflow() -> int:
+    return total(values=extract())
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+@step
+def total(values: list[int]) -> int:
+    return sum(values)
+
+@pipeline
+def simple_pipeline() -> None:
+    total(values=extract())
+```
+
+**Key differences:** this is the cleanest case, but Flyte task interfaces and registration semantics are still richer than a bare `@step`.
+
+## Dynamic Workflow (`@dynamic`)
+
+### Flyte
+
+```python
+from flytekit import dynamic, task, workflow
+
+@task
+def split_items(n: int) -> list[int]:
+    return list(range(n))
+
+@task
+def process(x: int) -> int:
+    return x * 2
+
+@dynamic
+def dynamic_body(items: list[int]) -> list[int]:
+    return [process(x=i) for i in items]
+
+@workflow
+def dynamic_workflow(n: int = 3) -> list[int]:
+    return dynamic_body(items=split_items(n=n))
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def split_items(n: int) -> list[int]:
+    return list(range(n))
+
+@step
+def process(x: int) -> int:
+    return x * 2
+
+@pipeline(dynamic=True)
+def dynamic_pipeline(n: int = 3) -> None:
+    items = split_items(n=n)
+    process.map(x=items)
+```
+
+**Migration warning:** do not translate a Flyte dynamic workflow into a static ZenML pipeline with a plain Python loop if the loop count depends on runtime values.
+
+## Eager Workflow (`@eager`)
+
+### Flyte
+
+```python
+from flytekit import eager, task
+
+@task
+def fetch(x: int) -> int:
+    return x + 1
+
+@eager
+async def eager_flow(x: int = 1) -> int:
+    return await fetch(x=x)
+```
+
+### ZenML redesign
+
+```python
+from zenml import pipeline, step
+
+@step
+def fetch(x: int) -> int:
+    return x + 1
+
+@pipeline
+def eager_replacement(x: int = 1) -> None:
+    fetch(x=x)
+```
+
+**Key differences:** `@eager` is not a safe decorator swap. ZenML has no direct equivalent for Flyte's async imperative orchestration style. Treat this as a redesign boundary.
+
+## `map_task()`
+
+### Flyte
+
+```python
+from flytekit import map_task, task, workflow
+
+@task
+def is_even(x: int) -> bool:
+    return x % 2 == 0
+
+@workflow
+def parity_workflow(values: list[int]) -> list[bool]:
+    return map_task(is_even, concurrency=4)(x=values)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def is_even(x: int) -> bool:
+    return x % 2 == 0
+
+@pipeline(dynamic=True)
+def parity_pipeline(values: list[int]) -> None:
+    is_even.map(x=values)
+```
+
+**Key differences:** Flyte's `concurrency` and `min_success_ratio` semantics do not carry over automatically. `.map()` is only the closest behavioral neighbour.
+
+## `conditional()`
+
+### Flyte
+
+```python
+from flytekit import conditional, task, workflow
+
+@task
+def is_positive(x: int) -> bool:
+    return x > 0
+
+@task
+def pos() -> str:
+    return "positive"
+
+@task
+def neg() -> str:
+    return "non-positive"
+
+@workflow
+def conditional_workflow(x: int = 5) -> str:
+    flag = is_positive(x=x)
+    return (
+        conditional("sign")
+        .if_(flag.is_true())
+        .then(pos())
+        .else_()
+        .then(neg())
+    )
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def is_positive(x: int) -> bool:
+    return x > 0
+
+@step
+def pos() -> str:
+    return "positive"
+
+@step
+def neg() -> str:
+    return "non-positive"
+
+@pipeline(dynamic=True)
+def conditional_pipeline(x: int = 5) -> None:
+    flag = is_positive(x=x)
+    if flag.load():
+        pos()
+    else:
+        neg()
+```
+
+**Migration warning:** if the original branch relied on Flyte promise semantics deep inside the workflow, verify the dynamic ZenML version carefully.
+
+## FlyteFile and FlyteDirectory
+
+### Flyte
+
+```python
+from pathlib import Path
+from flytekit import task, workflow
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile
+
+@task
+def write_report() -> FlyteFile:
+    path = Path("report.txt")
+    path.write_text("hello")
+    return FlyteFile(path)
+
+@task
+def bundle(report: FlyteFile) -> FlyteDirectory:
+    out = Path("bundle")
+    out.mkdir(exist_ok=True)
+    (out / "report.txt").write_text(Path(report.path).read_text())
+    return FlyteDirectory(out)
+```
+
+### ZenML
+
+```python
+from pathlib import Path
+from zenml import pipeline, step
+
+@step
+def write_report() -> Path:
+    path = Path("report.txt")
+    path.write_text("hello")
+    return path
+
+@step
+def bundle(report: Path) -> Path:
+    out = Path("bundle")
+    out.mkdir(exist_ok=True)
+    (out / "report.txt").write_text(report.read_text())
+    return out
+
+@pipeline
+def file_pipeline() -> None:
+    bundle(report=write_report())
+```
+
+**Key differences:** a naive `FlyteFile` → `str` translation is unsafe. If the original workflow depended on remote URI or provenance semantics, use a wrapper type and custom materializer instead of a bare path.
+
+## StructuredDataset
+
+### Flyte
+
+```python
+import pandas as pd
+from flytekit import task, workflow
+from flytekit.types.structured import StructuredDataset
+
+@task
+def load_table() -> StructuredDataset:
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    return StructuredDataset(dataframe=df)
+
+@task
+def sum_x(ds: StructuredDataset) -> int:
+    df = ds.open(pd.DataFrame).all()
+    return int(df["x"].sum())
+```
+
+### ZenML
+
+```python
+import pandas as pd
+from zenml import pipeline, step
+
+@step
+def load_table() -> pd.DataFrame:
+    return pd.DataFrame({"x": [1, 2, 3]})
+
+@step
+def sum_x(df: pd.DataFrame) -> int:
+    return int(df["x"].sum())
+
+@pipeline
+def dataset_pipeline() -> None:
+    sum_x(df=load_table())
+```
+
+**Key differences:** Flyte `StructuredDataset` can carry reader / writer / backend metadata. Add validation or metadata logging if that mattered in the source workflow.
+
+## ImageSpec and Per-Task Containers
+
+### Flyte
+
+```python
+from flytekit import ImageSpec, task
+
+train_image = ImageSpec(
+    name="trainer",
+    packages=["scikit-learn==1.5.1", "pandas==2.2.2"],
+)
+
+@task(container_image=train_image)
+def train() -> str:
+    return "trained"
+```
+
+### ZenML
+
+```python
+from zenml import step
+from zenml.config.docker_settings import DockerSettings
+
+train_settings = DockerSettings(
+    requirements=["scikit-learn==1.5.1", "pandas==2.2.2"],
+)
+
+@step(settings={"docker": train_settings})
+def train() -> str:
+    return "trained"
+```
+
+**Key differences:** the intent maps well, but the image build lifecycle and reproducibility story are not identical. Validate the final image story explicitly.
+
+## Resources and GPU Requests
+
+### Flyte
+
+```python
+from flytekit import Resources, task
+
+@task(
+    requests=Resources(cpu="2", mem="4Gi", gpu="1"),
+    limits=Resources(cpu="4", mem="8Gi", gpu="1"),
+)
+def train() -> str:
+    return "trained"
+```
+
+### ZenML
+
+```python
+from zenml import step
+from zenml.config.resource_settings import ResourceSettings
+
+@step(settings={"resources": ResourceSettings(cpu_count=4, memory="8Gi", gpu_count=1)})
+def train() -> str:
+    return "trained"
+```
+
+**Key differences:** Flyte separates requests and limits more explicitly. ZenML exposes portable hints whose final enforcement depends on the target stack.
+
+## Caching with `cache_version`
+
+### Flyte
+
+```python
+from flytekit import task
+
+@task(cache=True, cache_version="v2")
+def expensive_square(x: int) -> int:
+    return x * x
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+@step(enable_cache=True)
+def expensive_square(x: int, cache_buster: str = "v2") -> int:
+    return x * x
+```
+
+**Key differences:** the safe migration is an explicit cache-buster parameter or config value. Do not claim a first-class identical `cache_version` field unless you have verified it for the target ZenML version.
+
+## Retries and Timeouts
+
+### Flyte
+
+```python
+from datetime import timedelta
+from flytekit import task
+
+@task(retries=3, timeout=timedelta(minutes=10))
+def flaky_step() -> str:
+    return "ok"
+```
+
+### ZenML
+
+```python
+from zenml import step
+from zenml.config.retry_config import StepRetryConfig
+
+@step(retry=StepRetryConfig(max_retries=3, delay=60, backoff=2))
+def flaky_step() -> str:
+    return "ok"
+```
+
+**Key differences:** retries map fairly well. Timeout portability does not. Treat timeout migration as orchestrator-specific unless you have verified the target backend.
+
+## LaunchPlans and Scheduling
+
+### Flyte
+
+```python
+from datetime import timedelta
+from flytekit import FixedRate, LaunchPlan, task, workflow
+
+@task
+def train(learning_rate: float, epochs: int) -> str:
+    return f"lr={learning_rate}, epochs={epochs}"
+
+@workflow
+def training_workflow(learning_rate: float = 0.01, epochs: int = 5) -> str:
+    return train(learning_rate=learning_rate, epochs=epochs)
+
+daily_lp = LaunchPlan.get_or_create(
+    name="daily-training",
+    workflow=training_workflow,
+    default_inputs={"learning_rate": 0.01},
+    fixed_inputs={"epochs": 10},
+    schedule=FixedRate(duration=timedelta(days=1)),
+)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config.schedule import Schedule
+
+@step
+def train(learning_rate: float, epochs: int) -> str:
+    return f"lr={learning_rate}, epochs={epochs}"
+
+@pipeline
+def training_pipeline(learning_rate: float = 0.01, epochs: int = 5) -> None:
+    train(learning_rate=learning_rate, epochs=epochs)
+
+if __name__ == "__main__":
+    daily = Schedule(cron_expression="0 0 * * *")
+    training_pipeline.with_options(schedule=daily)(learning_rate=0.01, epochs=10)
+```
+
+**Key differences:** the schedule translates, but `LaunchPlan` is much more than a schedule. `default_inputs`, `fixed_inputs`, notifications, and execution identity all need explicit redesign.
+
+## Raw `ContainerTask`
+
+### Flyte
+
+```python
+from flytekit import workflow
+from flytekit.core.container_task import ContainerTask
+from flytekit.types.file import FlyteFile
+from flytekit import kwtypes
+
+sed_task = ContainerTask(
+    name="sed-task",
+    image="bash:5.2",
+    command=["/bin/sh", "-c", "sed 's/foo/bar/g' {{.inputs.infile}} > {{.outputs.out}}"],
+    inputs=kwtypes(infile=FlyteFile),
+    outputs=kwtypes(out=FlyteFile),
+)
+
+@workflow
+def container_workflow(infile: FlyteFile) -> FlyteFile:
+    return sed_task(infile=infile)
+```
+
+### ZenML redesign
+
+```python
+from pathlib import Path
+from zenml import pipeline, step
+
+@step
+def run_container_job(infile: Path) -> Path:
+    # TODO(migration): replace with explicit job submission, IO staging,
+    # and output collection. ZenML has no first-class ContainerTask analogue.
+    raise NotImplementedError
+
+@pipeline
+def container_pipeline(infile: Path) -> None:
+    run_container_job(infile=infile)
+```
+
+**Migration warning:** Flyte `ContainerTask` is a first-class raw-container primitive with typed file-based IO. ZenML has no safe direct equivalent. Treat this as a redesign boundary, not a code translation exercise.

--- a/skills/zenml-flyte-migration/skills/flyte-migration/references/concept-map.md
+++ b/skills/zenml-flyte-migration/skills/flyte-migration/references/concept-map.md
@@ -1,0 +1,128 @@
+# Flyte → ZenML Concept Map
+
+Complete mapping of Flyte concepts to their ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (conceptual equivalent with different semantics), **absent** (no safe ZenML equivalent), or **absent / unknown** where the public Union/Flyte material was too thin for a confident migration claim.
+
+## Table of Contents
+
+- [Core Workflow Primitives](#core-workflow-primitives)
+- [Type System and Data Passing](#type-system-and-data-passing)
+- [Execution Features](#execution-features)
+- [Infrastructure and Containerization](#infrastructure-and-containerization)
+- [Scheduling, LaunchPlans, and Notifications](#scheduling-launchplans-and-notifications)
+- [Plugin-backed and External Execution Patterns](#plugin-backed-and-external-execution-patterns)
+- [Union / Commercial Extensions](#union--commercial-extensions)
+- [Orchestrator Scheduling Support](#orchestrator-scheduling-support)
+
+## Core Workflow Primitives
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@task` | `@step` | approximate | Closest basic execution unit, but Flyte task interfaces and runtime semantics are richer. |
+| `@workflow` | `@pipeline` | approximate | Both compose execution units, but registration and trigger semantics differ. |
+| nested workflow / subworkflow | nested pipeline composition or wrapper pipeline | approximate | Works conceptually, but registration and LaunchPlan behavior do not carry over 1:1. |
+| `@dynamic` | `@pipeline(dynamic=True)` | approximate | Both allow runtime-shaped DAGs, but ZenML uses `.load()` and has orchestrator limits. |
+| `@eager` | no direct core equivalent | absent | Treat as a redesign boundary, not a decorator swap. |
+| Flyte promises / node outputs | step invocation handles + artifacts | approximate | Similar authoring feel, different engine semantics. |
+| `.with_overrides(...)` | `.with_options(...)` + settings | approximate | Similar intent, different scope and backend support. |
+
+## Type System and Data Passing
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| primitives and collections | same Python types | direct | Best-case migration. |
+| `Enum` | `str`, `Literal[...]`, or enum + custom materializer | approximate | Preserve the closed value set explicitly. |
+| dataclass values | dataclass + materializer / JSON model | approximate | Make serialization explicit. |
+| Pydantic `BaseModel` | dict / dataclass / custom materializer | approximate | Preserve validation intentionally. |
+| `Annotated[T, metadata]` | `Annotated[T, "artifact_name"]` + explicit metadata logging | absent / approximate | Flyte metadata-bearing annotations do not map cleanly. |
+| `FlyteFile` | `Path` artifact | approximate | Recreate remote-reference / provenance semantics when needed. |
+| `FlyteDirectory` | `Path` to directory artifact | approximate | Same warning as `FlyteFile`. |
+| `FlyteSchema` | dataframe or table artifact + validator | approximate | Prefer explicit schema checks. |
+| `StructuredDataset` | `pd.DataFrame`, `polars.DataFrame`, or `pyarrow.Table` artifact | approximate | Recreate storage / format metadata intentionally. |
+| arbitrary Python object | custom materializer or temporary `CloudpickleMaterializer` | absent / approximate | Cloudpickle is a transition tactic, not the desired endpoint. |
+
+## Execution Features
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `map_task()` | dynamic pipeline `.map()` | approximate | Similar purpose, different runtime and backend semantics. |
+| `map_task(concurrency=...)` | orchestrator-dependent parallelism controls | absent / approximate | No portable 1:1 core knob. |
+| `map_task(min_success_ratio=...)` | custom reducer / error-tolerant redesign | absent | Must be redesigned explicitly. |
+| `conditional()` | `@pipeline(dynamic=True)` + `.load()` + Python control flow | approximate | Similar branching goal, different execution semantics. |
+| `cache=True` | `@step(enable_cache=True)` | approximate | Similar intent. |
+| `cache_version="..."` | explicit cache-buster parameter or config | approximate | No first-class identical ZenML core field is documented in the existing repo guidance. |
+| retries | `StepRetryConfig(max_retries=...)` | approximate | Usually a good translation. |
+| timeout | backend-specific timeout handling | absent / approximate | Treat as target-stack-specific unless verified. |
+| `interruptible=True` | backend-level spot / preemptible config | absent | No portable ZenML core equivalent. |
+| intra-task checkpointing | split into smaller steps + persisted artifacts | absent | Strong redesign boundary. |
+| Decks | metadata logging, report artifacts, visualizers | approximate | No direct Deck object equivalent. |
+
+## Infrastructure and Containerization
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Resources(cpu=..., mem=..., gpu=...)` | `ResourceSettings(cpu_count=..., memory=..., gpu_count=...)` | approximate | Same intent, different enforcement model. |
+| requests / limits split | `ResourceSettings(...)` | approximate | Flyte is more explicit about requests vs limits. |
+| `ImageSpec(...)` | `DockerSettings(...)` | approximate | Similar purpose, different build lifecycle. |
+| per-task image overrides | step-level Docker settings | approximate | Possible, but not identical to Flyte image packaging. |
+| Flyte secrets access | ZenML secrets store / service connectors | approximate | Similar outcome, different abstraction. |
+| `ContainerTask` | wrapper step / step operator / external job submission | absent | No first-class raw container task primitive in ZenML core. |
+
+## Scheduling, LaunchPlans, and Notifications
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `LaunchPlan.get_or_create()` | deployment / `with_options(schedule=...)` + config | approximate | Schedule maps; registered execution surface does not. |
+| default LaunchPlan | default pipeline invocation / deployment config | approximate | Not a first-class registered object in the same way. |
+| `default_inputs` | pipeline defaults / config | approximate | Usually straightforward. |
+| `fixed_inputs` | wrapper pipeline or deployment-specific hard-coded config | approximate | Must be made explicit. |
+| scheduled LaunchPlan | `Schedule(...)` | approximate | Only the scheduling slice maps directly. |
+| LaunchPlan notifications | step hooks / alerter hooks / external alerts | approximate | Different abstraction level. |
+| embedded LaunchPlans / separate execution | wrapper pipeline or external orchestration | absent / approximate | Do not assume nested execution identity matches. |
+| `reference_workflow` | no direct equivalent | absent | Redesign as a shared library boundary, API/service boundary, or explicit artifact exchange. |
+| `reference_task` | no direct equivalent | absent | Cross-project registered entity references do not map cleanly to ZenML core. |
+| `reference_launch_plan` | no direct equivalent | absent | Cross-project registered references must be redesigned. |
+
+## Plugin-backed and External Execution Patterns
+
+| Flyte Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Spark plugin | Spark step operator / external Spark job step | approximate | Good intent-level match. |
+| Ray plugin | Ray step operator / external Ray launcher | approximate | Similar target, different integration abstraction. |
+| Dask plugin | Dask step operator / external Dask submission | approximate | Same warning. |
+| MPI / Kubeflow MPI plugin | custom operator or external launcher | absent / approximate | No first-class core equivalent. |
+| SageMaker plugin | SageMaker orchestrator / step operator / service integration | approximate | Depends on the target ZenML stack. |
+| BigQuery / Snowflake / SQL family | normal SDK / SQL client step | approximate | Usually rewrite as explicit code or external job boundary. |
+| dbt plugin | dbt step / containerized dbt run / external service | approximate | Usually a wrapper step. |
+| Databricks plugin / tasks | Databricks step operator or external job submission | approximate | Translate the boundary, not the config object. |
+| notebook / papermill-style external execution | wrapper step or external service | approximate | Keep inputs and outputs explicit. |
+
+## Union / Commercial Extensions
+
+| Union Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Union Cloud managed Flyte hosting | ZenML server / managed platform | approximate | Same broad problem space, different platform semantics. |
+| Union RBAC | ZenML Pro / server-side multi-user controls | approximate | Do not assume a 1:1 policy model. |
+| control plane / data plane split | platform architecture choice | approximate | Architectural similarity, not a code-level mapping. |
+| reusable containers / `ReusePolicy` | long-lived runners / service-style optimization | absent / approximate | No direct ZenML core equivalent. |
+| Union Actors / persistent execution | no direct core equivalent | absent | Strong redesign boundary. |
+| Union Artifacts | unclear stable public equivalent | absent / unknown | Preserve the uncertainty; do not over-claim a mapping. |
+| Union Channels | unclear stable public equivalent | absent / unknown | Public semantics were not clear enough for a safe migration claim. |
+
+## Orchestrator Scheduling Support
+
+ZenML scheduling support is orchestrator-dependent. This matters because Flyte LaunchPlan scheduling is a platform primitive, while ZenML `Schedule` only works where the active orchestrator supports it.
+
+| ZenML Orchestrator | Scheduling Support | Supported Types |
+|---|---|---|
+| Airflow | yes | cron, interval |
+| AzureML | yes | cron, interval |
+| Databricks | yes | cron |
+| HyperAI | yes | cron, one-time |
+| Kubeflow | yes | cron, interval |
+| Kubernetes | yes | cron |
+| Local | no | none |
+| Local Docker | no | none |
+| SageMaker | yes | cron, interval, one-time |
+| SkyPilot (AWS / Azure / GCP / Lambda) | no | none |
+| Tekton | no | none |
+| Vertex | yes | cron |

--- a/skills/zenml-flyte-migration/skills/flyte-migration/references/gaps-and-flags.md
+++ b/skills/zenml-flyte-migration/skills/flyte-migration/references/gaps-and-flags.md
@@ -1,0 +1,308 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the patterns that are most dangerous to silently approximate during a Flyte → ZenML migration — the places where similar-looking code would tell a different execution story after translation.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Flyte Equivalent](#zenml-features-with-no-flyte-equivalent)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### FlyteFile / FlyteDirectory pointer semantics
+
+**What Flyte does:** `FlyteFile` and `FlyteDirectory` are remote-aware transport types. Flyte can localize them into the execution environment automatically.
+
+**Why it matters:** a plain string or local path in ZenML may work in local testing and then quietly break on remote execution.
+
+**ZenML gap:** `Path` is the closest artifact type, but it does not automatically preserve remote-reference semantics or provenance.
+
+**Redesign approaches:**
+- use `Path` plus explicit metadata for the source URI
+- build a wrapper type + custom materializer
+- use `ExternalArtifact` / `register_artifact` when the file comes from outside the current run
+
+### StructuredDataset / FlyteSchema metadata contracts
+
+**What Flyte does:** these types represent more than “some table.” They can carry schema, reader/writer, or backend-format expectations.
+
+**Why it matters:** translating them to `Any` or a bare dataframe without validation hides assumptions that were previously encoded in the Flyte transport layer.
+
+**ZenML gap:** dataframe artifacts are a good payload match, but not a full metadata-contract match.
+
+**Redesign approaches:**
+- use concrete dataframe/table types
+- add a validator step
+- log the missing format/schema metadata explicitly
+- create a custom materializer if the metadata is operationally important
+
+### `map_task()` advanced semantics
+
+**What Flyte does:** `map_task()` is a first-class fan-out primitive with engine-level behavior. Flyte can also express concurrency and partial-success semantics.
+
+**Why it matters:** a naive `.map()` or plain Python loop can silently change parallelism, retry behavior, and failure semantics.
+
+**ZenML gap:** dynamic `.map()` is only an approximate match. There is no portable equivalent for `min_success_ratio`, and concurrency behavior is backend-specific.
+
+**Redesign approaches:**
+- use `@pipeline(dynamic=True)` + `.map()` when the target orchestrator supports it
+- batch or chunk inputs if backend concurrency must be controlled
+- redesign partial-success behavior as an explicit reducer / threshold step
+
+### `conditional()` and runtime graph shaping
+
+**What Flyte does:** models runtime branching inside the workflow engine using promises.
+
+**Why it matters:** the graph that actually runs can differ based on runtime data.
+
+**ZenML gap:** ZenML dynamic pipelines can branch with `.load()`, but the control flow is Python-side and not the same engine primitive.
+
+**Redesign approaches:**
+- use a dynamic pipeline with `.load()` when the branch logic is simple and backend support exists
+- move the decision inside a step and keep the outer pipeline simpler
+- split pre-branch and post-branch logic into separate pipelines
+
+### `@eager`
+
+**What Flyte does:** supports async imperative orchestration using Flyte tasks.
+
+**Why it matters:** eager execution is closer to a warm interactive runner than to a static or dynamic declarative graph.
+
+**ZenML gap:** no direct core equivalent.
+
+**Redesign approaches:**
+- redesign as a normal static pipeline
+- redesign as a dynamic pipeline
+- move the imperative coordination outside ZenML and let ZenML own the durable steps
+
+### LaunchPlans beyond simple scheduling
+
+**What Flyte does:** `LaunchPlan` is the registered execution surface with schedules, defaults, fixed inputs, and notifications.
+
+**Why it matters:** if you migrate only the cron expression, the user loses part of the original behavior without realizing it.
+
+**ZenML gap:** `Schedule` only covers the scheduling slice.
+
+**Redesign approaches:**
+- map schedule to `Schedule(...)`
+- map defaults to pipeline defaults or config
+- map fixed inputs to wrapper pipelines or deployment-specific config
+- map notifications to hooks / alerters / external alerting
+
+### `interruptible=True` and timeouts
+
+**What Flyte does:** exposes task-level spot / preemptible intent and task timeout semantics.
+
+**Why it matters:** cost profile, retry story, and “hung task” behavior can change materially.
+
+**ZenML gap:** no portable core equivalent for interruptible semantics, and timeout handling is backend-specific.
+
+**Redesign approaches:**
+- move spot/preemptible behavior into the target orchestrator configuration
+- keep retries explicit with `StepRetryConfig`
+- split very long steps into smaller idempotent units
+
+### ContainerTask and plugin `task_config`
+
+**What Flyte does:** `ContainerTask` and many plugin-backed tasks represent execution contracts, not just ordinary Python callables.
+
+**Why it matters:** if you translate only the Python wrapper, you lose the actual runtime boundary and IO protocol.
+
+**ZenML gap:** no first-class raw container task primitive, and no 1:1 translation for plugin config objects.
+
+**Redesign approaches:**
+- wrap the external job as a submission step
+- use a step operator when ZenML has one for the target system
+- preserve explicit input/output staging
+
+### Reference entities
+
+**What Flyte does:** `reference_task`, `reference_workflow`, and `reference_launch_plan` let a workflow point to already-registered entities in other projects.
+
+**Why it matters:** that is an architecture boundary, not just a code import.
+
+**ZenML gap:** no direct equivalent for cross-project registered entity references.
+
+**Redesign approaches:**
+- shared libraries
+- API/service boundaries
+- explicit artifact exchange or external job triggers
+
+### Intra-task checkpointing
+
+**What Flyte does:** allows a task to save progress and resume partway through.
+
+**Why it matters:** collapsing checkpointed logic into one large ZenML step makes retries more expensive and brittle.
+
+**ZenML gap:** no core equivalent.
+
+**Redesign approaches:**
+- split the task into smaller idempotent steps
+- persist intermediate outputs as artifacts
+- redesign the task as chunked processing
+
+### Union-only extensions
+
+**What Flyte / Union does:** adds higher-level hosted and commercial features such as Actors, reusable containers, and other platform-specific semantics.
+
+**Why it matters:** these can look like “just another option flag” when they are really architecture-level features.
+
+**ZenML gap:** some concepts have intent-level approximations, but several do not.
+
+**Redesign approaches:**
+- treat Actors as a redesign boundary
+- treat reusable containers as backend optimization, not portable code behavior
+- keep Union Artifacts / Channels conservative if the semantics are unclear
+
+---
+
+## Behavioral Differences
+
+These are the semantic differences that are often safe to translate, but important to explain clearly to the user.
+
+### Type system
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| cross-boundary type story | richer transport types and runtime localization | Python types + materializers |
+| file / directory types | `FlyteFile`, `FlyteDirectory` | usually `Path` artifacts |
+| tabular types | `StructuredDataset`, `FlyteSchema` | dataframe / table artifacts |
+| complex models | dataclass / Pydantic support in workflow transport | explicit serializer/materializer strategy |
+| arbitrary objects | extensible type adaptation | temporary cloudpickle escape hatch, but not a stable endpoint |
+
+**Practical impact:** migrate business payloads directly, but migrate transport semantics deliberately.
+
+### Containerization
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| image customization | task image via `ImageSpec` or task image fields | step/pipeline image settings via `DockerSettings` |
+| build lifecycle | part of Flyte packaging story | tied to the ZenML stack / image-build flow |
+| raw non-Python execution | `ContainerTask` | no core equivalent |
+
+### Parallel execution
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| fan-out primitive | `map_task()` | dynamic `.map()` |
+| graph shaping | engine-level | Python-side dynamic execution |
+| concurrency control | explicit `concurrency` | backend-specific |
+| partial success | `min_success_ratio` | no portable equivalent |
+
+### Caching
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| enable / disable | task-level cache flag | step-level cache flag |
+| explicit version knob | `cache_version` | no verified identical core field in current repo guidance |
+| hashing / serialization | tied to Flyte task interface behavior | influenced by materializers and step behavior |
+
+### Resource management / spot handling
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| CPU / memory / GPU | task `Resources` plus requests / limits | `ResourceSettings` |
+| interruptible / spot | first-class `interruptible=True` | backend-specific config |
+| timeouts | first-class task timeout | backend-specific timeout handling |
+
+### Scheduling / LaunchPlans
+
+| Aspect | Flyte | ZenML |
+|---|---|---|
+| schedule | LaunchPlan schedule | `Schedule` |
+| execution surface | LaunchPlan is the registered trigger object | pipeline + deployment/config tooling |
+| frozen inputs | `fixed_inputs` | wrapper pipeline / deployment config |
+| defaults | `default_inputs` | pipeline defaults / YAML config |
+| notifications | LaunchPlan notifications | hooks / alerters / external alerts |
+
+---
+
+## Migration Decision Tree
+
+Use this procedure on every Flyte component:
+
+```text
+1) Start with the authoring shape
+   ├── Plain @task / @workflow with only primitives and collections
+   │   -> translate first to @step / @pipeline
+   ├── @dynamic
+   │   -> candidate for @pipeline(dynamic=True)
+   └── @eager
+       -> FLAG HIGH: redesign boundary
+
+2) Inspect all inputs and outputs
+   ├── FlyteFile / FlyteDirectory
+   │   -> choose Path vs wrapper type + materializer intentionally
+   ├── StructuredDataset / FlyteSchema
+   │   -> choose concrete dataframe/table + validation/materializer strategy
+   ├── metadata-bearing Annotated / complex transport types
+   │   -> FLAG for explicit metadata redesign
+   └── plain Python types
+       -> direct / near-direct candidate
+
+3) Ask whether graph shape depends on runtime data
+   ├── No
+   │   -> static pipeline likely works
+   ├── Yes, via @dynamic / conditional / map_task
+   │   -> dynamic pipeline candidate
+   └── Yes, but depends on engine-only semantics
+       -> FLAG HIGH / redesign
+
+4) Check execution metadata
+   ├── retries
+   │   -> StepRetryConfig
+   ├── resources
+   │   -> ResourceSettings
+   ├── images
+   │   -> DockerSettings
+   ├── timeout / interruptible
+   │   -> FLAG as backend-specific
+   └── cache_version
+       -> explicit cache-buster config
+
+5) Check scheduling and trigger surface
+   ├── LaunchPlan schedule only
+   │   -> Schedule(...)
+   ├── LaunchPlan + defaults/fixed inputs/notifications
+   │   -> split into explicit config + wrapper/deployment concepts
+   └── reference_launch_plan
+       -> FLAG HIGH: redesign
+
+6) Check external execution boundaries
+   ├── plugin task / external job family
+   │   -> intent-level mapping (step operator or submission step)
+   ├── ContainerTask
+   │   -> FLAG HIGH: redesign
+   ├── reference_task / reference_workflow
+   │   -> FLAG HIGH: architecture boundary
+   └── checkpointing / Union Actors
+       -> FLAG HIGH: redesign
+
+7) Classify final result
+   ├── Semantics mostly preserved
+   │   -> direct
+   ├── Same intent, different runtime story
+   │   -> approximate
+   └── No safe equivalent
+       -> absent
+```
+
+---
+
+## ZenML Features with No Flyte Equivalent
+
+These are capabilities worth mentioning in the migration report as "what you get for free" after migration.
+
+| ZenML Capability | Flyte Equivalent | Notes |
+|---|---|---|
+| `register_artifact` / `ExternalArtifact` as explicit lineage tools | no close Flyte core equivalent | Useful for bringing pre-existing data into lineage cleanly |
+| Model Control Plane with model versioning and promotion stages | no Flyte core equivalent | Strong gain for ML lifecycle management |
+| service connectors as a first-class auth abstraction | no close Flyte core equivalent | Centralized cloud auth story is stronger here |
+| YAML-driven multi-environment pipeline configuration | no close Flyte core equivalent | Helpful when replacing LaunchPlan variants with environment-specific config |
+| step success / failure hooks as core callback surfaces | only loose approximation via LaunchPlan notifications | More callback-like than Flyte's notification object model |

--- a/skills/zenml-kedro-migration/plugin.json
+++ b/skills/zenml-kedro-migration/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "zenml-kedro-migration",
+  "version": "1.0.0",
+  "description": "Migrate Kedro pipelines and projects to idiomatic ZenML pipelines with concept mapping, Data Catalog to artifact translation, code translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "kedro",
+    "migration",
+    "mlops",
+    "pipelines",
+    "catalog",
+    "artifacts"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-kedro-migration/skills/kedro-migration/SKILL.md
+++ b/skills/zenml-kedro-migration/skills/kedro-migration/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: kedro-to-zenml-migration
+description: >-
+  Migrate Kedro pipelines and projects to idiomatic ZenML pipelines. Handles
+  concept mapping (node->step, Pipeline->pipeline, Data Catalog->explicit
+  boundary steps plus artifacts, params:->typed parameters), catalog analysis,
+  code translation, hooks/runners/deployment mapping, and flags unsupported
+  patterns (transcoding, dataset lifecycle hooks, namespace remapping,
+  SharedMemoryDataset, slicing semantics) for human review. Use this skill
+  whenever the user mentions Kedro migration, converting a Kedro project to
+  ZenML, porting Kedro pipelines, replacing Kedro orchestration or deployment
+  plugins with ZenML, or asks how a Kedro concept maps to ZenML -- even if they
+  do not explicitly say "migrate". Also use when the user pastes `catalog.yml`,
+  `parameters.yml`, `pipeline_registry.py`, node code, hook code, or describes
+  a workflow using Kedro terminology such as node, pipeline, Data Catalog,
+  `params:`, namespace, modular pipeline, runner, `MemoryDataset`, or
+  transcoding in a ZenML context. If the user just asks a quick conceptual
+  question ("what is the ZenML equivalent of `MemoryDataset`?"), answer it
+  directly from the concept map -- no need to run the full migration workflow.
+---
+
+# Migrate Kedro to ZenML
+
+This skill translates Kedro projects into idiomatic ZenML pipelines. It handles the full migration workflow: analyze the Kedro project, classify each pattern as direct / approximate / absent, translate what maps cleanly, flag what needs redesign, and produce a working ZenML project plus a clear migration report.
+
+## How migration works at a high level
+
+Kedro and ZenML are both Python-first workflow systems, so the business logic inside node functions often survives migration surprisingly well. The hard part is not the node code. The hard part is the **contract around the node code**.
+
+Kedro uses the **Data Catalog** as the central registry of datasets, storage details, credentials, versioning, and sometimes representation tricks such as transcoding. ZenML does **not** have a `DataCatalog` equivalent. ZenML treats internal handoffs as typed **artifacts** and expects external reads and writes to be made explicit in step code, materializers, stack settings, and secrets.
+
+So this migration is not a rename exercise. It is mostly a careful rewrite of:
+
+1. **Boundary handling** -- catalog-driven reads and writes become explicit loader/exporter steps
+2. **Data flow** -- string dataset names become typed artifact edges
+3. **Configuration and auth** -- `parameters.yml` and `credentials.yml` move into ZenML parameters, YAML config, secrets, and stack settings
+4. **Operational semantics** -- runners, slicing, hooks, namespaces, and deployment plugins must be checked for behavior drift
+
+### The three mapping types
+
+Every Kedro concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Similar intent exists but semantics differ | Translate with caveats noted in the migration report |
+| **Absent** | No ZenML equivalent exists | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Kedro Project
+
+Ask the user for the Kedro project files. Read them before writing any code. Prefer this order because it reveals the real contract of the system:
+
+1. `conf/base/catalog.yml` and any environment-specific catalog files
+2. `conf/base/parameters.yml` and related parameter files
+3. `conf/local/credentials.yml` references if present
+4. node files (`nodes.py` and related modules)
+5. pipeline files (`pipeline.py`, modular pipeline factories)
+6. `pipeline_registry.py`
+7. `settings.py`
+8. custom dataset classes
+9. hook implementations
+10. runner or deployment usage (`kedro run`, Airflow/Kubeflow/Vertex/Docker plugins, CI entrypoints)
+
+For each project, inventory the following **before** deciding how to migrate it:
+
+1. **Catalog structure** -- Which datasets are external inputs, external outputs, intermediates, free runtime datasets, versioned datasets, credential-bound datasets, transcoded aliases, partitioned datasets, incremental datasets, or custom datasets?
+2. **Node graph** -- Which nodes are pure transforms and which nodes are really IO boundaries hidden behind catalog entries?
+3. **Parameters** -- Which inputs come from `params:` references? Are they simple scalars, nested config objects, or runtime overrides?
+4. **Namespaces and modular pipelines** -- Is reuse relying on automatic remapping or namespace-prefixed dataset names?
+5. **Hooks** -- Any `before_node_run`, `after_node_run`, `on_node_error`, dataset lifecycle hooks, command hooks, or catalog hooks?
+6. **Execution habits** -- Does the team rely on `--from-nodes`, `--to-nodes`, `--tags`, `--from-inputs`, `--to-outputs`, or `--only-missing-outputs`?
+7. **Runners** -- `SequentialRunner`, `ParallelRunner`, `ThreadRunner`, `SharedMemoryDataset`, or other memory-sensitive behavior?
+8. **Deployment intent** -- Is Kedro being exported to Airflow, Kubeflow, Vertex AI, Docker, or paired with `kedro-mlflow` / Kedro-Viz?
+
+### Phase 2: Classify and Plan
+
+After Phase 1, classify everything as direct / approximate / absent using [references/concept-map.md](references/concept-map.md) and [references/gaps-and-flags.md](references/gaps-and-flags.md).
+
+#### Quick classification guide
+
+**Direct or nearly direct translations (usually safe to generate automatically):**
+- Plain node function -> `@step`
+- Multiple inputs / outputs -> step args + tuple returns with `Annotated[...]`
+- `Pipeline` -> `@pipeline`
+- `parameters.yml` + `params:` -> typed pipeline / step parameters
+- Registry-organized project -> normal Python module layout
+
+**Approximate translations (generate, but explain what changed):**
+- `pandas.CSVDataset`, `ParquetDataset`, `JSONDataset`, `ExcelDataset` -> explicit loader/exporter boundary steps
+- `versioned: true` -> ZenML artifact versioning, explicit external version handling, or both
+- custom datasets -> loader/exporter logic and sometimes custom materializers
+- `ParallelRunner` -> orchestrator-managed parallelism with isolated steps
+- `kedro-mlflow` -> ZenML experiment tracker
+- `kedro-docker` -> `DockerSettings` and stack-driven containerization
+- deployment plugins -> ZenML orchestrators and stack components
+
+**Absent / redesign required (must be flagged):**
+- `DataCatalog` as a global dataset registry
+- transcoding (`dataset@pandas`, `dataset@spark`)
+- automatic namespace/remapping semantics
+- `SharedMemoryDataset` / `SharedMemoryDataCatalog`
+- dataset lifecycle hooks
+- slicing semantics (`--from-nodes`, `--to-nodes`, `--only-missing-outputs`, etc.)
+- dataset factories and catch-all pattern resolution
+
+#### Present the migration plan before generating code
+
+Before writing code, summarize your findings for the user:
+
+> "Here's what I found in your Kedro project:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with caveats): [list]
+> - **Needs redesign** (cannot be auto-migrated safely): [list]
+>
+> The main migration theme is: [for example, 'catalog-driven IO becomes explicit boundary steps'].
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain each one concretely:
+- what the Kedro project currently does
+- why ZenML cannot preserve that behavior automatically
+- what the safest redesign approach looks like
+
+### Phase 3: Generate ZenML Code
+
+Translate the Kedro project into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── load_customers.py
+│   ├── transform_features.py
+│   └── export_report.py
+├── pipelines/
+│   └── my_pipeline.py
+├── materializers/            # Only when truly needed
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # argparse, not click
+├── README.md
+└── pyproject.toml
+```
+
+Key rules:
+- One step per file in `steps/`
+- Keep the pipeline definition separate from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` should use `requires-python = ">=3.12"` and `zenml>=0.94.1`
+- Always generate `configs/dev.yaml` and `configs/prod.yaml`
+- Always generate a `README.md`
+- Run `zenml init` at the project root
+
+#### Core translation rules
+
+See [references/code-patterns.md](references/code-patterns.md) for the concrete side-by-side examples. Use these rules consistently:
+
+1. **Pure nodes become steps**
+   - Move the node body into a `@step`
+   - Add explicit type hints to all inputs and outputs
+   - Use `Annotated[...]` when stable output names matter
+
+2. **Catalog-driven IO becomes boundary steps**
+   - File reads, table reads, report exports, and service writes should be explicit
+   - Do not keep catalog-name indirection for internal edges
+   - Internal handoffs should usually be artifacts, not persisted files
+
+3. **`params:` becomes explicit typed parameters**
+   - Convert `params:threshold` into a pipeline or step parameter
+   - Put defaults and environment-specific overrides in YAML config
+   - Do not recreate an implicit global parameter object if step signatures can stay explicit
+
+4. **Versioning must be decided, not assumed**
+   - If Kedro used versioned files for reproducibility only, ZenML artifact versioning may be enough
+   - If downstream systems rely on concrete versioned paths, keep explicit exporter logic
+   - If both matter, implement both
+
+5. **Hooks only map partially**
+   - `@step(on_success=...)` and `@step(on_failure=...)` are only partial substitutes
+   - Dataset lifecycle hooks almost always need to be rebuilt at explicit boundaries
+   - Do not claim a missing before-hook exists when it does not
+
+6. **Namespaces and modular pipelines become explicit composition**
+   - Reuse the same step graph via helper functions or wrapper pipelines
+   - Use explicit invocation IDs and parameters
+   - Do not silently mimic Kedro namespace behavior with simple string prefixes
+
+7. **Runners and deployment plugins become stack design**
+   - Translate runner expectations into orchestrator choice, resource settings, and step operators
+   - Translate Airflow/Kubeflow/Vertex/Docker plugin intent into stack configuration
+
+#### Comment style in generated code
+
+Keep migration comments short and actionable:
+- Use `# Migration note:` for brief inline caveats
+- Use `# TODO(migration):` for required manual follow-up
+
+Do not hide major semantic differences in comments alone. They must also appear in the migration report.
+
+#### Handling approximate translations
+
+When the migration is approximate, explain the difference right at the point of use:
+
+```python
+@step
+def load_orders(path: str) -> pd.DataFrame:
+    # Migration note: Kedro previously loaded this dataset through catalog.yml
+    # with credentials and versioning managed outside the node code. In ZenML
+    # that boundary is explicit here and configured via parameters + secrets.
+    return pd.read_csv(path)
+```
+
+#### Handling absent patterns
+
+Never silently approximate patterns with no real ZenML equivalent. Instead:
+
+1. Add a clear `# TODO(migration):` comment in generated code
+2. Record it in `MIGRATION_REPORT.md`
+3. Offer a redesign approach
+
+```python
+# TODO(migration): UNSUPPORTED -- this Kedro project relied on transcoding
+# (`features@pandas` and `features@spark`) for the same logical dataset.
+# ZenML has no equivalent hidden representation switch. Pick one canonical
+# artifact representation and make conversions explicit in dedicated steps.
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root:
+
+```markdown
+# Migration Report: [Kedro Project] -> [ZenML Pipeline]
+
+## Summary
+- **Source**: Kedro project `[project_name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Nodes migrated**: X direct, Y approximate, Z flagged
+- **Catalog entries analyzed**: N
+
+## Direct Translations
+| Kedro Concept | ZenML Equivalent | Notes |
+|---|---|---|
+| node(clean_orders) | steps/clean_orders.py | Pure transform |
+
+## Approximate Translations
+| Kedro Pattern | ZenML Equivalent | What Changed |
+|---|---|---|
+| pandas.CSVDataset | explicit loader/exporter steps | IO boundary is now explicit |
+| versioned: true | artifact versioning + optional external export versioning | File-path semantics may differ |
+
+## Flagged for Review
+| Kedro Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| transcoding | HIGH | No hidden representation switching in ZenML | Use explicit conversion steps |
+| before_dataset_loaded hook | HIGH | No dataset lifecycle hook equivalent | Move logic into loader step |
+
+## Catalog Translation Summary
+| Catalog Entry | Original Type | Migration Target | Notes |
+|---|---|---|---|
+| raw_orders | pandas.CSVDataset | load_orders step | external input |
+| model | pickle.PickleDataset | artifact + exporter step | check path/version semantics |
+
+## Configuration Migration Summary
+- `parameters.yml` keys moved to: [pipeline config path(s)]
+- Runtime overrides previously passed through: [Kedro mechanism]
+- New ZenML config entrypoints: [dev/prod yaml files]
+
+## Credential / Auth Migration Summary
+- `credentials.yml` entries moved to ZenML secrets / env vars / service connectors
+- Any manual setup still required: [list]
+
+## Namespace / Composition Summary
+- Which modular pipelines were preserved
+- Which namespaces/remappings required explicit wrapper logic
+
+## Runner / Deployment Migration Summary
+- Original runner(s): [SequentialRunner / ParallelRunner / ThreadRunner]
+- Original plugins: [kedro-airflow / kedro-kubeflow / kedro-vertexai / kedro-docker / kedro-mlflow]
+- New ZenML stack assumptions: [orchestrator / step operator / tracking setup]
+
+## Limitations and Key Differences
+[Put the most important behavior differences here BEFORE the benefits section]
+
+## What's NOT Migrated
+[List unsupported or intentionally deferred patterns]
+
+## What You Get for Free After Migration
+- Artifact versioning and lineage
+- Step caching
+- Stack abstraction
+- Stronger typed artifact flow
+- Optional dynamic pipelines and cross-pipeline artifact reuse
+- Better alignment with experiment trackers, step operators, and deployment workflows
+
+## Recommended Next Steps
+1. Run `zenml-quick-wins`
+2. Install the ZenML docs MCP server
+3. Use `zenml-pipeline-authoring` for deeper Docker / materializer / YAML / deployment work
+4. Follow up on every HIGH-severity flag before production use
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a **Recommended Next Steps** section in the migration report **and** communicate it to the user directly.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+Always suggest this first:
+
+> "Now that the migration is done, I recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerters, and other production features."
+
+#### 2. Include documentation links for flagged patterns
+
+For every flagged pattern, include relevant ZenML documentation links when they help:
+
+- YAML configuration: `https://docs.zenml.io/concepts/steps_and_pipelines/yaml_configuration`
+- Secrets: `https://docs.zenml.io/concepts/secrets`
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- Containerization: `https://docs.zenml.io/concepts/containerization`
+- Step operators: `https://docs.zenml.io/stacks/stack-components/step-operators/custom`
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML docs while you keep iterating, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Community support for unsupported patterns
+
+When there are HIGH-severity flags, offer to help the user ask the ZenML community for guidance. **When there are 2+ HIGH-severity flags**, generate a ready-to-send Slack message for `zenml.io/slack` that includes:
+- what Kedro project is being migrated
+- the exact unsupported patterns
+- what workarounds were suggested
+- what behavior might change if the workaround is used
+
+#### 5. Open GitHub issues for genuine product gaps
+
+When the migration reveals a real missing ZenML capability -- not merely a different design, but a genuine gap that multiple users would benefit from -- offer to open a GitHub issue on `zenml-io/zenml`.
+
+#### 6. Suggest `/simplify`
+
+After migration, always suggest running `/simplify` on the generated code so migration comments, wrappers, and duplication can be cleaned up.
+
+#### 7. Further customization via `zenml-pipeline-authoring`
+
+Recommend `zenml-pipeline-authoring` when the user needs deeper help with:
+- `DockerSettings`
+- YAML configuration
+- custom materializers
+- step operators
+- deployments
+- multi-environment architecture
+
+## Important Behavioral Differences to Communicate
+
+Always mention the relevant behavior differences in the migration report.
+
+### Data Catalog != Artifact Store
+
+Kedro uses a named dataset registry that hides storage details from node code. ZenML uses typed artifacts flowing between steps. That means the migration often adds explicit loader/exporter steps at the edges of the graph.
+
+### `MemoryDataset` != "stay in memory"
+
+Kedro can keep intermediates ephemeral. ZenML artifacts are normally persisted and versioned. If ephemerality mattered for correctness or cost, flag it.
+
+### Namespaces != simple prefixes
+
+Kedro namespaces and remapping change how datasets and parameters resolve. ZenML reuse is explicit Python composition. These are related ideas, not the same feature.
+
+### Slicing != caching
+
+Kedro's CLI slicing changes which part of a graph runs. ZenML caching reuses outputs when inputs, code, and settings match. Do not present them as equivalents.
+
+### Runners != orchestrators
+
+Kedro runners are not a direct code-level concept in ZenML. Translate them into stack design, step isolation assumptions, and resource settings.
+
+## Anti-Patterns to Avoid
+
+- Do **not** recreate a fake `DataCatalog` abstraction on top of ZenML unless the user explicitly wants a transitional adapter and understands the tradeoff.
+- Do **not** convert every Kedro dataset into a custom materializer. Many Kedro datasets are storage adapters, not artifact types.
+- Do **not** silently flatten transcoding into one representation.
+- Do **not** claim dataset lifecycle hooks or namespace remapping "basically work the same".
+- Do **not** force a full repo layout rewrite before behavior is correct.
+
+## Additional References
+
+- [references/concept-map.md](references/concept-map.md) -- full Kedro -> ZenML concept map
+- [references/code-patterns.md](references/code-patterns.md) -- side-by-side translation examples
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- must-flag patterns, behavioral differences, and decision tree

--- a/skills/zenml-kedro-migration/skills/kedro-migration/references/code-patterns.md
+++ b/skills/zenml-kedro-migration/skills/kedro-migration/references/code-patterns.md
@@ -1,0 +1,593 @@
+# Kedro -> ZenML Code Patterns
+
+These examples show the **shape** of the migration, not the only valid implementation. The goal is to make the boundary shift obvious: Kedro hides IO behind the Data Catalog; ZenML makes boundary IO explicit and keeps internal edges as typed artifacts.
+
+## Table of Contents
+
+- [1. Simple pipeline with catalog datasets](#1-simple-pipeline-with-catalog-datasets)
+- [2. Parameters from `parameters.yml` and `params:`](#2-parameters-from-parametersyml-and-params)
+- [3. Multiple inputs and outputs on one node](#3-multiple-inputs-and-outputs-on-one-node)
+- [4. Modular pipelines with namespacing](#4-modular-pipelines-with-namespacing)
+- [5. Pipeline slicing and partial reruns](#5-pipeline-slicing-and-partial-reruns)
+- [6. Versioned datasets](#6-versioned-datasets)
+- [7. Credentials and secret handling](#7-credentials-and-secret-handling)
+- [8. Hooks such as `before_node_run` and `on_node_error`](#8-hooks-such-as-before_node_run-and-on_node_error)
+- [9. `ParallelRunner` and `ThreadRunner` semantics](#9-parallelrunner-and-threadrunner-semantics)
+- [10. Experiment tracking with `kedro-mlflow`](#10-experiment-tracking-with-kedro-mlflow)
+- [11. Spark datasets and transcoding](#11-spark-datasets-and-transcoding)
+- [12. Free and intermediate datasets](#12-free-and-intermediate-datasets)
+- [13. Modular pipeline remapping](#13-modular-pipeline-remapping)
+- [14. Deployment patterns](#14-deployment-patterns)
+
+## 1. Simple pipeline with catalog datasets
+
+### Kedro
+
+```yaml
+# conf/base/catalog.yml
+raw_customers:
+  type: pandas.CSVDataset
+  filepath: data/01_raw/customers.csv
+
+customer_stats:
+  type: json.JSONDataset
+  filepath: data/08_reporting/customer_stats.json
+```
+
+```python
+node(clean_customers, "raw_customers", "clean_customers")
+node(summarize_customers, "clean_customers", "customer_stats")
+```
+
+### ZenML
+
+```python
+from typing import Annotated
+import pandas as pd
+from zenml import pipeline, step
+
+
+@step
+def load_raw_customers(path: str) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+
+@step
+def clean_customers_step(customers: pd.DataFrame) -> pd.DataFrame:
+    ...
+
+
+@step
+def summarize_customers_step(df: pd.DataFrame) -> Annotated[dict[str, float], "customer_stats"]:
+    ...
+
+
+@step
+def export_stats(stats: dict[str, float], output_path: str) -> str:
+    ...
+
+
+@pipeline
+def customers_pipeline(raw_customers_path: str, customer_stats_path: str) -> None:
+    raw = load_raw_customers(path=raw_customers_path)
+    clean = clean_customers_step(customers=raw)
+    stats = summarize_customers_step(df=clean)
+    export_stats(stats=stats, output_path=customer_stats_path)
+```
+
+**Key differences**
+- Reads and writes become explicit steps
+- Internal datasets become artifacts, not file-path aliases
+
+**Migration warning**
+- Do not pass report file paths between transformation steps unless they are truly external boundaries.
+
+---
+
+## 2. Parameters from `parameters.yml` and `params:`
+
+### Kedro
+
+```python
+node(
+    filter_high_value_orders,
+    inputs=["orders", "params:high_value_threshold"],
+    outputs="high_value_orders",
+)
+```
+
+### ZenML
+
+```python
+@step
+def filter_high_value_orders_step(
+    orders: pd.DataFrame,
+    high_value_threshold: float,
+) -> pd.DataFrame:
+    ...
+
+
+@pipeline
+def orders_pipeline(
+    orders_path: str,
+    high_value_threshold: float,
+) -> None:
+    orders = load_orders(path=orders_path)
+    filter_high_value_orders_step(
+        orders=orders,
+        high_value_threshold=high_value_threshold,
+    )
+```
+
+```yaml
+# configs/dev.yaml
+parameters:
+  orders_path: data/01_raw/orders.csv
+  high_value_threshold: 1000.0
+```
+
+**Key differences**
+- `params:` becomes a typed function parameter
+- YAML config still exists, but it is not a Data Catalog
+
+**Migration warning**
+- Do not hide parameter use inside global config reads if a step signature can make the contract explicit.
+
+---
+
+## 3. Multiple inputs and outputs on one node
+
+### Kedro
+
+```python
+node(
+    score_customers,
+    inputs={"customers": "customers", "orders": "orders", "bias": "params:bias"},
+    outputs=["scored_rows", "score_summary"],
+)
+```
+
+### ZenML
+
+```python
+from typing import Annotated
+
+
+@step
+def score_customers_step(
+    customers: pd.DataFrame,
+    orders: pd.DataFrame,
+    bias: float,
+) -> tuple[
+    Annotated[pd.DataFrame, "scored_rows"],
+    Annotated[dict[str, float], "score_summary"],
+]:
+    ...
+```
+
+**Key differences**
+- The multi-output capability survives well
+- Output names are artifact names, not catalog names with hidden resolution rules
+
+**Migration warning**
+- If the original project relied on output names for catalog factories or namespace tricks, this translation is incomplete without an explicit redesign.
+
+---
+
+## 4. Modular pipelines with namespacing
+
+### Kedro
+
+```python
+active = pipeline(base_training, namespace="active", parameters={"params:min_rows": "params:active_min_rows"})
+candidate = pipeline(base_training, namespace="candidate", parameters={"params:min_rows": "params:candidate_min_rows"})
+return active + candidate
+```
+
+### ZenML
+
+```python
+def training_subgraph(features: pd.DataFrame, min_rows: int, prefix: str) -> dict[str, float]:
+    train, test = split_rows_step(features=features, min_rows=min_rows, id=f"{prefix}_split")
+    model = fit_rule_model_step(train=train, id=f"{prefix}_fit")
+    return evaluate_rule_model_step(model=model, test=test, id=f"{prefix}_evaluate")
+
+
+@pipeline
+def compare_models_pipeline(
+    features_path: str,
+    active_min_rows: int,
+    candidate_min_rows: int,
+) -> None:
+    features = load_features(path=features_path)
+    training_subgraph(features=features, min_rows=active_min_rows, prefix="active")
+    training_subgraph(features=features, min_rows=candidate_min_rows, prefix="candidate")
+```
+
+**Key differences**
+- Reuse is explicit Python composition
+- Invocation IDs replace hidden namespace-driven graph identity
+
+**Migration warning**
+- Never claim that namespace prefixes alone reproduce Kedro namespace semantics.
+
+---
+
+## 5. Pipeline slicing and partial reruns
+
+### Kedro
+
+```bash
+kedro run --pipeline=training --from-nodes=build_features
+kedro run --pipeline=training --only-missing-outputs
+```
+
+### ZenML
+
+```python
+import pandas as pd
+from zenml import pipeline, step
+
+
+@step
+def load_saved_features(path: str) -> pd.DataFrame:
+    return pd.read_parquet(path)
+
+
+@pipeline
+def train_from_saved_features_pipeline(features_path: str) -> None:
+    features = load_saved_features(path=features_path)
+    train_model_step(features=features)
+```
+
+**Key differences**
+- Kedro slicing changes which part of a predefined graph runs
+- ZenML usually handles this with smaller entrypoint pipelines, explicit reload steps, artifact reuse, and caching
+
+**Migration warning**
+- Do not present caching as a true equivalent of slicing. If you want cross-run reuse, design an explicit entrypoint around a stable saved artifact or an explicit external boundary.
+
+---
+
+## 6. Versioned datasets
+
+### Kedro
+
+```yaml
+features:
+  type: pandas.ParquetDataset
+  filepath: data/05_model_input/features.parquet
+  versioned: true
+```
+
+```bash
+kedro run --load-versions=features:2024-06-04T09.52.53.123Z
+```
+
+### ZenML
+
+```python
+from typing import Annotated
+from pathlib import Path
+import pandas as pd
+from zenml import ArtifactConfig
+
+
+@step
+def build_features_step() -> Annotated[
+    pd.DataFrame,
+    ArtifactConfig(name="features", version="release_2026_04_07"),
+]:
+    ...
+
+
+@step
+def export_features_version(features: pd.DataFrame, output_dir: str, version: str) -> str:
+    path = Path(output_dir) / version / "features.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    features.to_parquet(path, index=False)
+    return str(path)
+```
+
+**Key differences**
+- Kedro versions file-backed datasets
+- ZenML versions artifacts in the lineage graph
+
+**Migration warning**
+- If downstream systems relied on concrete versioned file paths, keep exporter logic instead of relying on artifact versioning alone.
+
+---
+
+## 7. Credentials and secret handling
+
+### Kedro
+
+```yaml
+# catalog.yml
+orders:
+  type: pandas.CSVDataset
+  filepath: s3://company-bucket/orders.csv
+  credentials: orders_s3
+```
+
+```yaml
+# credentials.yml
+orders_s3:
+  key: ...
+  secret: ...
+```
+
+### ZenML
+
+```python
+@step
+def load_orders(path: str, aws_secret_name: str) -> pd.DataFrame:
+    # Migration note: auth is now explicit and should come from ZenML secrets
+    import os
+    import pandas as pd
+
+    credentials = os.environ[aws_secret_name]
+    return pd.read_csv(path, storage_options={"token": credentials})
+```
+
+**Key differences**
+- Auth is no longer attached to a dataset name in a global catalog
+- The credential flow becomes explicit in stack config, service connectors, or secret-backed code
+
+**Migration warning**
+- Never inline `credentials.yml` values into checked-in ZenML config.
+
+---
+
+## 8. Hooks such as `before_node_run` and `on_node_error`
+
+### Kedro
+
+```python
+class ProjectHooks:
+    @hook_impl
+    def before_node_run(self, node, catalog, inputs, is_async, session_id):
+        validate_inputs(inputs)
+
+    @hook_impl
+    def on_node_error(self, error, node, catalog, inputs, is_async, session_id):
+        notify(error, node.name)
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+
+@step(on_failure=my_failure_hook)
+def transform_step(df: pd.DataFrame) -> pd.DataFrame:
+    validate_inputs({"df": df})
+    ...
+```
+
+**Key differences**
+- ZenML can approximate success/failure hooks
+- It does not offer the same before-step or dataset lifecycle hook surface
+
+**Migration warning**
+- Move preconditions into explicit validation steps or wrapper code rather than pretending a missing hook exists.
+
+---
+
+## 9. `ParallelRunner` and `ThreadRunner` semantics
+
+### Kedro
+
+```bash
+kedro run --runner=ParallelRunner
+```
+
+### ZenML
+
+```python
+@pipeline
+def training_pipeline() -> None:
+    prepared = prepare_data_step()
+    train_a_step(data=prepared)
+    train_b_step(data=prepared)
+```
+
+**Key differences**
+- Parallelism is now orchestrator-managed, often with isolated containers
+- Shared memory and same-process assumptions usually disappear
+
+**Migration warning**
+- Re-test memory use, startup cost, and shared-state assumptions. "It runs branches in parallel" is not enough.
+
+---
+
+## 10. Experiment tracking with `kedro-mlflow`
+
+### Kedro
+
+```yaml
+# conf/local/mlflow.yml
+server:
+  mlflow_tracking_uri: http://mlflow:5000
+```
+
+### ZenML
+
+```python
+from typing import Any
+import pandas as pd
+
+
+@step
+def train_model_step(train_df: pd.DataFrame) -> dict[str, Any]:
+    # experiment tracker is attached through the active stack
+    metrics = {"row_count": len(train_df)}
+    model = {"baseline_mean": float(train_df["target"].mean())}
+    return {"model": model, "metrics": metrics}
+```
+
+**Key differences**
+- Kedro often injects tracking through a plugin and hooks
+- ZenML attaches trackers through the stack and step context
+
+**Migration warning**
+- Preserve the tracking intent, not the plugin wiring.
+
+---
+
+## 11. Spark datasets and transcoding
+
+### Kedro
+
+```yaml
+features@spark:
+  type: spark.SparkDataset
+  filepath: s3://bucket/features
+
+features@pandas:
+  type: pandas.ParquetDataset
+  filepath: s3://bucket/features
+```
+
+### ZenML
+
+```python
+@step
+def load_features_spark(path: str) -> "SparkDataFrame":
+    ...
+
+
+@step
+def spark_to_pandas_step(df: "SparkDataFrame") -> pd.DataFrame:
+    ...
+```
+
+**Key differences**
+- Representation switching becomes explicit conversion logic
+- One canonical representation should own the contract
+
+**Migration warning**
+- Never silently collapse transcoding into a single representation without telling the user.
+
+---
+
+## 12. Free and intermediate datasets
+
+### Kedro
+
+```python
+node(build_features, "raw_rows", "features")
+node(train_model, "features", "model")
+```
+
+When `features` is undeclared, Kedro may materialize it as a runtime-only dataset.
+
+### ZenML
+
+```python
+@pipeline
+def training_pipeline(raw_rows_path: str) -> None:
+    raw = load_raw_rows(path=raw_rows_path)
+    features = build_features_step(rows=raw)
+    train_model_step(features=features)
+```
+
+**Key differences**
+- The natural ZenML translation persists `features` as an artifact
+- This may be a feature, but it is still a behavior change
+
+**Migration warning**
+- If the original project depended on ephemerality for privacy, cost, or storage behavior, flag it explicitly.
+
+---
+
+## 13. Modular pipeline remapping
+
+### Kedro
+
+```python
+pipeline(
+    base_training,
+    inputs={"features": "candidate_features"},
+    outputs={"model": "candidate_model"},
+    parameters={"params:min_rows": "params:candidate_min_rows"},
+)
+```
+
+### ZenML
+
+```python
+def candidate_training_subgraph(
+    candidate_features: pd.DataFrame,
+    candidate_min_rows: int,
+) -> dict[str, float]:
+    return training_subgraph(
+        features=candidate_features,
+        min_rows=candidate_min_rows,
+        prefix="candidate",
+    )
+```
+
+**Key differences**
+- Kedro remapping is declarative and dataset-name-driven
+- ZenML remapping is explicit argument passing and wrapper composition
+
+**Migration warning**
+- If the Kedro project relies on heavy remapping for reuse, expect more structural rewrite.
+
+---
+
+## 14. Deployment patterns
+
+### Kedro
+
+```bash
+kedro docker build
+kedro airflow create
+kedro kubeflow compile
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+from zenml.config import DockerSettings, ResourceSettings, Schedule
+
+
+docker_settings = DockerSettings(requirements=["pandas", "scikit-learn"])
+resource_settings = ResourceSettings(cpu_count=2, memory="8Gi")
+schedule = Schedule(cron_expression="0 2 * * *")
+
+
+@pipeline(
+    settings={
+        "docker": docker_settings,
+        "resources": resource_settings,
+    }
+)
+def training_pipeline() -> None:
+    ...
+
+
+training_pipeline.with_options(schedule=schedule)()
+```
+
+**Key differences**
+- Kedro often exports the project into a platform-specific artifact
+- ZenML keeps one pipeline definition and changes the active stack / orchestrator
+
+**Migration warning**
+- Migrate the **deployment intent** (scheduling, containerization, resources, tracker, secrets), not the plugin command itself.
+
+---
+
+## General Translation Rule of Thumb
+
+When you are unsure how to translate a Kedro pattern, ask:
+
+1. Is this an **internal artifact edge** or an **external boundary**?
+2. Is this behavior encoded in **catalog metadata**, **hook code**, or **runtime CLI habits**?
+3. Does ZenML have a real equivalent, or am I about to fake one?
+
+If the answer to the last question is "fake one", stop and flag it in the migration report.

--- a/skills/zenml-kedro-migration/skills/kedro-migration/references/concept-map.md
+++ b/skills/zenml-kedro-migration/skills/kedro-migration/references/concept-map.md
@@ -1,0 +1,159 @@
+# Kedro -> ZenML Concept Map
+
+Complete mapping of Kedro concepts to their closest ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (similar intent, different semantics), or **absent** (no real ZenML equivalent -- requires redesign).
+
+## Table of Contents
+
+- [Core Primitives](#core-primitives)
+- [Data Catalog and Datasets](#data-catalog-and-datasets)
+- [Configuration](#configuration)
+- [Execution](#execution)
+- [Hooks](#hooks)
+- [Plugins and Deployment](#plugins-and-deployment)
+- [Orchestrator Scheduling Support](#orchestrator-scheduling-support)
+
+## Core Primitives
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `node()` / `Node` | `@step` | approximate | Both wrap Python functions as DAG units, but Kedro binds dataset names while ZenML binds typed artifacts and parameters. |
+| Plain node function | Plain Python function under `@step` | approximate | Business logic often migrates cleanly, but type hints and artifact semantics become part of the runtime contract. |
+| String dataset names in `inputs` / `outputs` | Python variables connecting step calls | absent | ZenML has no catalog-name indirection for normal internal edges. |
+| Multiple node inputs / outputs | Step args plus tuple returns with `Annotated[...]` names | direct | Capability exists cleanly in both systems. |
+| Node `tags` | Run, artifact, and resource tags | approximate | ZenML has tags, but not Kedro's tag-based step-selection semantics. |
+| `Pipeline` | `@pipeline` | approximate | Both define DAGs, but Kedro composes through named datasets while ZenML composes through artifact dependencies. |
+| `pipeline()` helper | Python composition inside a `@pipeline` | approximate | Reuse intent is similar; the mechanics are explicit rather than namespace-driven. |
+| `Pipeline(..., inputs=..., outputs=..., parameters=...)` remapping | Wrapper pipeline or helper function with explicit args | absent | No built-in ZenML DSL for dataset-name remapping. |
+| `namespace=` | No direct equivalent | absent | ZenML reuse is explicit composition plus invocation IDs, not automatic dataset renaming. |
+| `prefix_datasets_with_namespace` | No direct equivalent | absent | There is no ZenML switch that prefixes selected edges automatically. |
+| `pipeline_registry.py` | Normal Python module organization | approximate | Kedro imposes a registry contract; ZenML does not. |
+| `__default__` pipeline | No direct equivalent | absent | In ZenML, you explicitly call the pipeline you want to run. |
+| Opinionated Kedro project structure | Flexible repo layout + stack config | absent | ZenML is much less prescriptive about directory structure. |
+| `kedro pipeline create` | Internal scaffolding or template workflow | approximate | Similar intent, no core ZenML equivalent. |
+| `kedro new --starter` | Internal repo template or Cookiecutter | approximate | Similar project bootstrap goal, different toolchain. |
+
+## Data Catalog and Datasets
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `DataCatalog` | No core equivalent | absent | ZenML has an artifact store plus materializers, not a registry of named datasets with IO config. |
+| `catalog.yml` | No single equivalent | absent | Its contents fan out across loader/exporter steps, YAML config, materializers, secrets, and stack settings. |
+| `pandas.CSVDataset` | `pd.DataFrame` artifact plus explicit CSV loader/exporter step | approximate | External CSV IO becomes an explicit boundary. |
+| `pandas.ParquetDataset` | DataFrame artifact plus explicit parquet boundary step | approximate | Artifact storage is not the same contract as "write parquet to this path". |
+| `json.JSONDataset` | `dict` / `list` artifact plus explicit JSON export if needed | approximate | Good fit for configuration payloads or reports. |
+| `pickle.PickleDataset` | Typed artifact with built-in or custom materializer | approximate | Do not assume "pickle file on disk" and "artifact in artifact store" are equivalent. |
+| `pandas.ExcelDataset` | DataFrame artifact plus explicit Excel export step | approximate | Best treated as a reporting boundary. |
+| `spark.SparkDataset` | Spark-based step code, often with step-operator support | approximate | Similar compute intent, not a catalog alias. |
+| `pillow.ImageDataset` | Image artifact type or explicit image-file IO | approximate | Similar use case, different storage contract. |
+| `PartitionedDataset` | Partition-discovery step plus dynamic pipeline or explicit loop | approximate | No built-in catalog wrapper that transparently exposes partitions. |
+| `IncrementalDataset` | Checkpoint artifact plus explicit "what is new?" logic | approximate | Checkpoint semantics need redesign. |
+| `MemoryDataset` | Normal upstream step output | approximate | Closest match, but ZenML persists artifacts by default. |
+| `SharedMemoryDataset` | No equivalent | absent | ZenML does not expose a shared-memory dataset edge. |
+| `SharedMemoryDataCatalog` | No equivalent | absent | Shared memory is not ZenML's artifact-sharing model. |
+| Dataset factories and catch-all patterns | No equivalent | absent | ZenML does not resolve dataset names through catalog patterns. |
+| Default runtime dataset patterns | No equivalent | absent | Kedro can synthesize runtime datasets; ZenML step outputs are explicit. |
+| `versioned: true` | Artifact versioning, explicit external version handling, or both | approximate | Similar goal, different storage and retrieval semantics. |
+| `credentials:` on datasets | Secrets, env vars, service connectors, stack auth | approximate | No dataset-local credential injection field in ZenML. |
+| `load_args`, `save_args`, `fs_args` | Step code, materializer code, or step settings | approximate | These become implementation details, not catalog metadata. |
+| Transcoding such as `dataset@pandas` / `dataset@spark` | No equivalent | absent | Must be redesigned explicitly. |
+| Custom dataset via `AbstractDataset` / `AbstractVersionedDataset` | Loader/exporter code or custom materializer | approximate | Depends on whether the class is a storage adapter or a true artifact type. |
+| `kedro-datasets` package | No single equivalent | absent | Migrate class by class as "boundary IO adapter" vs "artifact serialization concern". |
+| `KedroDataCatalog` experimental feature | No migration target | absent | Normalize back to ordinary catalog behavior before migrating. |
+| `kedro catalog describe-datasets` | No direct equivalent | absent | ZenML has artifact and stack inspection, but not catalog inspection because there is no `DataCatalog`. |
+| `kedro catalog list-patterns` | No direct equivalent | absent | Pattern-driven dataset resolution has no core ZenML equivalent. |
+| `kedro catalog resolve-patterns` | No direct equivalent | absent | Expand naming patterns into explicit boundaries before migrating. |
+
+## Configuration
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `conf/base/` | Shared YAML config files | approximate | Similar intent, different loader contract. |
+| `conf/local/` | Secrets, env-specific config, local stack settings | approximate | Similar separation of shared vs local concerns, different mechanics. |
+| `OmegaConfigLoader` | No core equivalent | absent | ZenML YAML config does not replicate Kedro's OmegaConf loader behavior. |
+| `globals.yml` | No core equivalent | absent | Use normal YAML, env vars, or your own config layer. |
+| `parameters.yml` | Pipeline or step parameters in YAML config | approximate | Friendly migration, but wiring becomes explicit in function signatures. |
+| `params:` prefix | Typed step or pipeline argument | approximate | Same intent, different syntax and visibility. |
+| Runtime override via `--params` or resolvers | Runtime pipeline args or YAML override | approximate | ZenML has runtime override precedence, but not Kedro's resolver model. |
+| `credentials.yml` | ZenML secrets, env vars, service connectors | approximate | Same responsibility, different mechanism. |
+| Environment-specific overrides | Multiple config files + active stack switching | approximate | Use `dev.yaml`, `prod.yaml`, and stack-specific settings. |
+| Custom OmegaConf resolvers | No core equivalent | absent | Re-implement only if the project depends on them heavily. |
+| `--config` / `--conf-source` | `.with_options(config_path=\"...\")` | approximate | Similar operational use, different loader architecture. |
+
+## Execution
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `kedro run` | Call a pipeline function | approximate | Same goal, different runtime model. |
+| `kedro run --pipeline=...` | Call a different ZenML pipeline | direct | Conceptually straightforward. |
+| `kedro run --node` / `--nodes` | Run a step directly or define a smaller pipeline | approximate | Useful during development, but not a drop-in slicing feature. |
+| `kedro run --tags` | No direct equivalent | absent | ZenML tags do not implement Kedro-style execution selection. |
+| `kedro run --namespaces` | No direct equivalent | absent | No runtime namespace selection mechanism. |
+| `--from-nodes`, `--to-nodes`, `--from-inputs`, `--to-outputs` | No direct equivalent | absent | Use smaller pipelines, dedicated backfill entrypoints, or artifact reuse. |
+| `--only-missing-outputs` | No direct equivalent | absent | Closest tools are caching and artifact reuse, but semantics differ. |
+| `SequentialRunner` | Local sequential orchestration | approximate | Closest operational match. |
+| `ParallelRunner` | Orchestrator-managed parallel branches | approximate | Isolation model is very different. |
+| `ThreadRunner` | No named equivalent | approximate | There is no ZenML "thread runner" abstraction. |
+| Async dataset load/save | Async pipeline execution | approximate | Similar wording, different semantics. |
+| Runner choice by CLI | Active stack and orchestrator choice | approximate | In ZenML the execution environment is a stack concern. |
+
+## Hooks
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `after_context_created` | No direct equivalent | absent | No matching lifecycle hook in ZenML core. |
+| `after_catalog_created` | No direct equivalent | absent | There is no `DataCatalog` lifecycle in ZenML. |
+| `before_pipeline_run` | Wrapper code before pipeline invocation | approximate | Not a formal ZenML hook. |
+| `after_pipeline_run` | `@pipeline(on_success=...)` | approximate | Similar high-level use, less context-rich. |
+| `on_pipeline_error` | `@pipeline(on_failure=...)` | approximate | Closest formal equivalent. |
+| `before_node_run` | No direct equivalent | absent | No official before-step hook in ZenML. |
+| `after_node_run` | `@step(on_success=...)` | approximate | Similar outcome hook, different payload. |
+| `on_node_error` | `@step(on_failure=...)` | approximate | Closest formal equivalent. |
+| `before_dataset_loaded` | No direct equivalent | absent | Dataset lifecycle hooks are a Kedro-specific strength. |
+| `after_dataset_loaded` | No direct equivalent | absent | Same issue. |
+| `before_dataset_saved` | No direct equivalent | absent | Same issue. |
+| `after_dataset_saved` | No direct equivalent | absent | Same issue. |
+| `before_command_run` | No direct equivalent | absent | ZenML CLI / Python execution does not expose a matching hook. |
+| `after_command_run` | No direct equivalent | absent | Same issue. |
+
+## Plugins and Deployment
+
+| Kedro Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `kedro-airflow` | Airflow orchestrator stack component | approximate | Kedro exports a Kedro project to Airflow DAGs; ZenML orchestrates steps directly on Airflow. |
+| `kedro-kubeflow` | Kubeflow orchestrator stack component | approximate | Same destination platform, different architecture. |
+| `kedro-vertexai` | Vertex orchestrator stack component | approximate | Same destination, different execution model. |
+| `kedro-docker` | `DockerSettings` plus stack-driven containerization | approximate | Kedro packages the whole project; ZenML usually builds execution images per stack / pipeline context. |
+| `kedro-mlflow` | ZenML MLflow experiment tracker | approximate | Similar tracking destination, different integration shape. |
+| Kedro-Viz pipeline graph | ZenML dashboard DAG and artifact views | approximate | Similar observability goal, different metadata model. |
+| Kedro-Viz native experiment tracking | No direct equivalent | absent | Use experiment trackers and metadata logging instead. |
+| `kedro-datasets` plugin ecosystem | No single equivalent | absent | ZenML has integrations and materializers, but not a catalog plugin layer of the same shape. |
+| Platform-specific Kedro deployment plugins generally | ZenML stacks, orchestrators, step operators, schedules | approximate | Kedro often exports to another platform; ZenML treats the platform as part of the stack. |
+
+## Orchestrator Scheduling Support
+
+ZenML scheduling is a wrapper around native orchestrator scheduling, not its own scheduler. Support therefore varies by orchestrator.
+
+| ZenML Orchestrator | Scheduling | Types Supported / Notes |
+|---|:---:|---|
+| Local | No | No native scheduling |
+| Local Docker | No | No native scheduling |
+| Airflow | Yes | Cron, interval |
+| AzureML | Yes | Cron, interval |
+| Databricks | Yes | Cron only |
+| HyperAI | Yes | Cron, one-time |
+| Kubeflow | Yes | Cron, interval |
+| Kubernetes | Yes | Cron |
+| SageMaker | Yes | Cron, interval, one-time |
+| SkyPilot | No | No native scheduling |
+| Tekton | No | No native scheduling |
+| Vertex AI | Yes | Cron |
+
+## Practical Translation Rule
+
+When in doubt, use this order of reasoning:
+
+1. Start from `catalog.yml`, not the nodes.
+2. Decide whether each dataset is a boundary or an internal handoff.
+3. Convert internal handoffs into artifacts.
+4. Convert boundary reads and writes into explicit steps.
+5. Flag anything that depends on hidden catalog behavior, namespaces, slicing, or dataset lifecycle hooks.

--- a/skills/zenml-kedro-migration/skills/kedro-migration/references/gaps-and-flags.md
+++ b/skills/zenml-kedro-migration/skills/kedro-migration/references/gaps-and-flags.md
@@ -1,0 +1,210 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the patterns that are most dangerous to silently approximate during Kedro -> ZenML migration: the places where Kedro and ZenML behave differently enough that a naive translation changes the real behavior of the pipeline.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Kedro Equivalent](#zenml-features-with-no-kedro-equivalent)
+- [Anti-Patterns](#anti-patterns)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+| Pattern | What Kedro does | Why it matters | ZenML gap | Redesign approaches |
+|---|---|---|---|---|
+| Data Catalog abstraction | Nodes are pure functions over dataset names resolved by `DataCatalog` | It hides IO location, type, auth, and versioning from node code | No `DataCatalog` equivalent | Convert external boundaries into loader/exporter steps, keep internal edges as artifacts, move config into YAML + stack settings + secrets |
+| Transcoding | Same logical dataset can be loaded as `dataset@pandas`, `dataset@spark`, etc. | Different consumers can see different concrete representations of the same data | No equivalent | Choose one canonical artifact representation and make conversions explicit in dedicated steps |
+| `MemoryDataset` and free datasets | Intermediates may be undeclared and ephemeral | Migration can accidentally turn ephemeral state into persisted artifacts | Closest match persists by default | Use normal step outputs, but explicitly acknowledge the persistence change and redesign if ephemerality mattered |
+| `SharedMemoryDataset` / `SharedMemoryDataCatalog` | Supports in-memory sharing for `ParallelRunner` | Shared-memory assumptions can fail badly on remote or isolated execution | No equivalent | Redesign around artifact passing, external stores, or explicit batching |
+| Credential injection via `credentials.yml` | Dataset auth is declared outside node code and referenced by dataset name | Auth becomes invisible coupling between catalog and runtime | No dataset-local auth hook | Move to ZenML secrets, env vars, service connectors, or explicit step-local auth |
+| Modular pipeline namespacing | Automatically prefixes dataset names and supports remapping | Reuse semantics depend on namespace resolution, not just labels | No equivalent | Replace with wrapper functions, explicit invocation IDs, and explicit parameter / boundary naming |
+| Pipeline slicing | `--from-nodes`, `--to-nodes`, `--tags`, `--only-missing-outputs` change runtime execution of the graph | Teams often rely on these for partial reruns and backfills | No equivalent | Split monolithic pipelines, promote reusable artifacts, create dedicated entrypoint pipelines |
+| `ParallelRunner` / `ThreadRunner` semantics | In-process concurrency with specific memory and Spark caveats | Migration can silently change memory-sharing and failure behavior | Only approximate via orchestrators | Re-benchmark branch structure, resource settings, data movement, and step isolation |
+| Dataset lifecycle hooks | `before_dataset_loaded`, `after_dataset_saved`, etc. | Validation, auditing, masking, or side effects may live here | No equivalent | Recreate logic in loader/exporter steps, custom materializers, or external platform hooks |
+| Dataset factories and catch-all patterns | Catalog patterns can synthesize datasets from names | A lot of "magic" may live in naming schemes | No equivalent | Expand into explicit boundaries or build your own thin config layer consciously |
+| Strict Kedro project structure | `conf/`, `src/`, `data/`, registry conventions | Teams may rely on these conventions for tooling and onboarding | ZenML is flexible | Keep structure temporarily if it lowers risk, then simplify later |
+
+---
+
+## Behavioral Differences
+
+### Data Catalog vs artifact store and materializers
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Primary abstraction | Named datasets in a catalog | Typed artifacts in an artifact store | Start migration from `catalog.yml`, then rewrite boundaries explicitly |
+| Internal edge meaning | Dataset name resolved at runtime | Artifact produced by an upstream step | Internal names stop being storage aliases and become lineage artifacts |
+| IO declaration | Declarative in catalog metadata | Usually explicit in step code or stack settings | Expect more boundary code in ZenML |
+| Serialization | Dataset implementation handles load/save | Materializer handles serialization based on Python type | Custom Kedro datasets often split into loader code plus optional materializer work |
+| Versioning | Versioned under dataset path | Versioned as artifacts with lineage | File-version semantics and artifact-version semantics are not interchangeable |
+
+### Configuration model
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Data config | `catalog.yml` | No single equivalent | Config fans out into steps, materializers, YAML, secrets, and stack settings |
+| Parameters | `parameters.yml` + `params:` | Pipeline / step parameters plus YAML config | Friendly migration, but wiring changes |
+| Secrets | `credentials.yml` | ZenML secrets, env vars, service connectors | Auth moves out of dataset definitions |
+| Loader semantics | OmegaConfigLoader and resolvers | ZenML YAML config hierarchy | If you depend on OmegaConf behavior, you may need a custom layer |
+
+### Project structure
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Repository layout | Opinionated, starter-driven layout | Flexible layout | Keep the old tree during the first pass if it reduces migration risk |
+| Pipeline discovery | Registry and `__default__` | Explicit pipeline functions | Remove reliance on registry conventions |
+| Scaffolding | `kedro new`, `kedro pipeline create` | No core equivalent | Project scaffolding becomes your internal tooling choice |
+
+### Hooks
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Hook granularity | Context, catalog, pipeline, node, dataset, command | Step and pipeline success/failure hooks | Hook-heavy Kedro code almost always needs redesign |
+| Before-step hooks | Yes | No | Put preconditions and validation in explicit steps or wrapper code |
+| Dataset lifecycle hooks | Yes | No | Move these concerns into boundary steps or custom materializers |
+
+### Runners vs orchestrators
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Execution control | Runner chooses sequential / process / thread behavior | Active stack and orchestrator choose runtime behavior | Translate runner assumptions into stack design, not just code |
+| Parallelism | Often same-machine concurrency | Often isolated remote step execution | Revisit memory, data transfer, and failure assumptions |
+| Scheduling | Usually via external platform plugins | Native schedule abstraction on supported orchestrators | Scheduling becomes part of deployment rather than a Kedro export plugin |
+
+### Testing philosophy
+
+| Topic | Kedro | ZenML | Migration consequence |
+|---|---|---|---|
+| Unit-test sweet spot | Pure node functions and catalog-backed integration tests | Pure step functions and artifact-backed integration tests | Most business logic tests survive almost unchanged |
+| Mocking strategy | Swap catalog entries, `MemoryDataset`, test catalogs | Test pure step bodies or small pipelines and inspect artifacts | Catalog-mocking tests often become loader/exporter-step tests |
+| Cross-pipeline reuse tests | Namespaces and remapping behavior matter | Artifact lineage and explicit wrapper pipelines matter | Tests need to move from "dataset names resolve correctly" to "artifacts and boundaries connect correctly" |
+
+---
+
+## Migration Decision Tree
+
+A reliable Kedro migration starts from the catalog, then moves outward.
+
+```text
+INPUT: catalog entries, parameters, nodes, pipelines, hooks, runners, deployment plugins
+
+STEP 1: CLASSIFY CATALOG ENTRIES
+  For each entry in catalog.yml:
+    - Is it an external input?
+    - Is it an external output?
+    - Is it an intermediate dataset?
+    - Is it a free runtime dataset / MemoryDataset?
+    - Is it versioned?
+    - Does it use credentials: ?
+    - Does it use transcoding?
+    - Is it partitioned / incremental / custom?
+
+STEP 2: DECIDE BOUNDARY VS INTERNAL EDGE
+  IF external input:
+    create explicit loader step
+    consider ExternalArtifact only if pre-existing data should enter the lineage graph directly
+  ELSE IF external output:
+    create explicit exporter step
+  ELSE:
+    prefer ordinary step output artifacts
+
+STEP 3: RESOLVE VERSIONING
+  IF versioned behavior was mainly for reproducibility:
+    use artifact versioning
+  ELSE IF downstream systems depend on concrete versioned paths:
+    keep explicit exporter logic
+  ELSE:
+    use both and document the split
+
+STEP 4: RESOLVE CREDENTIALS
+  IF catalog entry uses credentials:
+    move auth to secrets / env vars / service connectors / stack config
+    do not recreate dataset-local hidden auth
+
+STEP 5: TRANSLATE NODES
+  IF node is a pure transform:
+    convert to @step with typed inputs/outputs
+  ELSE IF node mainly performs boundary IO:
+    keep it as a dedicated loader/exporter step
+
+STEP 6: TRANSLATE PIPELINES AND COMPOSITION
+  IF namespaces or remapping are essential:
+    rebuild using wrapper functions, explicit invocation IDs, and explicit parameter wiring
+  ELSE:
+    compose steps directly in @pipeline functions
+
+STEP 7: HANDLE CLI SLICING HABITS
+  IF team depends on --from-nodes / --to-nodes / --only-missing-outputs / --tags:
+    design smaller entrypoint pipelines, artifact-reuse pipelines, or backfill-specific entrypoints
+    do not claim caching is equivalent
+
+STEP 8: HANDLE HOOKS
+  IF success/failure hook:
+    maybe map to step/pipeline hooks
+  ELSE IF dataset lifecycle hook:
+    rebuild explicitly in boundary steps or materializers
+
+STEP 9: HANDLE RUNNERS
+  Translate SequentialRunner / ParallelRunner / ThreadRunner into:
+    - orchestrator choice
+    - resource settings
+    - data movement design
+    - concurrency and isolation assumptions
+
+STEP 10: HANDLE DEPLOYMENT PLUGINS
+  Replace "export Kedro to platform X" with "run ZenML on stack X"
+  Move:
+    container behavior -> DockerSettings
+    resources -> ResourceSettings
+    schedules -> Schedule
+    tracking -> experiment tracker stack component
+```
+
+### Human-review checkpoints
+
+Stop and ask for confirmation when any of the following are true:
+
+- More than one HIGH-severity flag appears in the same pipeline
+- The project relies on transcoding
+- Namespace/remapping is central to reuse
+- Dataset lifecycle hooks contain business-critical logic
+- `SharedMemoryDataset` or shared-memory assumptions appear
+- The team depends heavily on slicing for production operations
+
+---
+
+## ZenML Features with No Kedro Equivalent
+
+These are worth calling out because migration can improve the system, not just reproduce it.
+
+| ZenML capability | What the user gains after migration | Notes |
+|---|---|---|
+| Stack abstraction | Same pipeline code can run against different orchestrators, artifact stores, trackers, and registries by switching stacks | Kedro plugins are usually platform-specific |
+| Artifact lineage | First-class traceability of step outputs | Kedro versioning is dataset-centric, not artifact-graph-centric |
+| Step caching | Skip re-execution when code, inputs, and settings match | Not the same as Kedro slicing |
+| External artifacts | Register pre-existing data as artifacts | Useful for bridging non-ZenML-produced data into the lineage graph |
+| Dynamic pipelines | Runtime-shaped DAGs for some fan-out / branching patterns | More flexible than static modular composition, but still not a universal replacement |
+| Step operators | Run specific steps in specialized environments | More granular than "run the whole project on platform X" |
+| Model Control Plane | Model versioning and promotion workflows | Goes beyond Kedro core and most Kedro plugins |
+| Rich metadata logging | Stronger artifact- and run-level metadata model | Good follow-up after the structural migration is stable |
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it is wrong | What to do instead |
+|---|---|---|
+| Recreating a fake `DataCatalog` on top of ZenML | Preserves the old mental model and hides the real artifact contract | Use explicit loader/exporter steps and artifact edges |
+| Treating `catalog.yml` as if it maps to one ZenML YAML file | The information fans out across steps, materializers, secrets, and stack settings | Split responsibilities intentionally |
+| Converting every Kedro dataset into a materializer | Many Kedro datasets are storage adapters, not artifact types | Use boundary steps for storage adapters; reserve materializers for true serialization concerns |
+| Silently flattening transcoding into one representation | Changes behavior without telling the user | Choose a canonical representation and add explicit conversion steps |
+| Treating caching as a substitute for slicing | Caching and slicing solve different problems | Build smaller pipelines or artifact-reuse entrypoints |
+| Porting `credentials.yml` into checked-in ZenML config | Weakens secret hygiene and misses ZenML's auth model | Use ZenML secrets, env vars, or service connectors |
+| Assuming `ParallelRunner` means "ZenML runs in parallel too" | The isolation and memory model are different | Re-evaluate branch structure, data size, and remote execution costs |
+| Forcing a full repo rewrite before semantics are correct | Adds churn while behavior is still moving | Keep the old Kedro layout temporarily if it reduces risk, then simplify later |

--- a/skills/zenml-metaflow-migration/plugin.json
+++ b/skills/zenml-metaflow-migration/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "zenml-metaflow-migration",
+  "version": "1.0.0",
+  "description": "Migrate Metaflow flows to idiomatic ZenML pipelines with FlowSpec mapping, artifact translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "metaflow",
+    "migration",
+    "mlops",
+    "pipelines",
+    "flows",
+    "flowspec",
+    "outerbounds"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-metaflow-migration/skills/metaflow-migration/SKILL.md
+++ b/skills/zenml-metaflow-migration/skills/metaflow-migration/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: metaflow-to-zenml-migration
+description: >-
+  Migrate Metaflow flows and Outerbounds-flavored Metaflow projects to
+  idiomatic ZenML pipelines. Handles concept mapping (FlowSpec->pipeline,
+  @step->@step, self.* artifacts->explicit returns and inputs), code
+  translation for Parameters, IncludeFile, Config, self.next transitions,
+  branch/join, foreach, scheduling, retry/resource/dependency decorators, and
+  flags unsupported or high-risk patterns (@catch, merge_artifacts, resume and
+  checkpoint semantics, recursion, event triggers, @batch) for human review.
+  Use this skill whenever the user mentions Metaflow migration, converting
+  FlowSpec code, porting flows from Metaflow or Outerbounds, replacing
+  Metaflow orchestration with ZenML, or asks how a Metaflow concept maps to
+  ZenML -- even if they don't explicitly say "migrate". Also use when they
+  paste FlowSpec code or describe workflows using Metaflow terminology
+  (self.next, foreach, current, Parameter, IncludeFile, Config, @catch,
+  @kubernetes, @batch, Runner, Deployer) in a ZenML context. If the user just
+  asks a quick conceptual question ("what's the ZenML equivalent of
+  merge_artifacts?"), answer it directly from the concept map -- no need to run
+  the full migration workflow.
+---
+
+# Migrate Metaflow to ZenML
+
+This skill translates Metaflow flows into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing `FlowSpec` code, classifying each pattern, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project.
+
+## How migration works at a high level
+
+Metaflow and ZenML are deceptively close cousins. Both talk about steps, artifacts, local vs remote execution, and moving the same code between environments. But they tell that story in different ways:
+
+- **Metaflow** builds a workflow around a `FlowSpec` class, `@step` methods, `self.next(...)` transitions, and `self.*` assignments that become persisted artifacts.
+- **ZenML** builds a workflow around a `@pipeline` function, standalone `@step` functions, and explicit step inputs and outputs that become typed, versioned artifacts.
+
+So this is not a rename-the-primitives migration. The dangerous cases are the ones that still "look right" after a naive rewrite but silently change behavior: join semantics, `foreach`, `merge_artifacts`, `@catch`, resume/checkpoint behavior, conditional branching, recursion, and platform-specific decorators like `@batch`.
+
+### The three mapping types
+
+Every Metaflow concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in the migration report |
+| **Absent** | No safe ZenML equivalent exists | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Metaflow Code
+
+Ask the user for their Metaflow flow files, supporting modules, configuration files, and any deployment/runtime commands they currently use. Read everything before writing code.
+
+For each flow, identify:
+
+1. **Flow structure**
+   - `FlowSpec` class name
+   - `start` and `end` steps
+   - every `self.next(...)` transition
+   - whether transitions are linear, branching, conditional, recursive, or `foreach`
+2. **Artifact flow**
+   - every `self.<name> = ...` assignment
+   - where each artifact is read later
+   - whether joins depend on implicit propagation or `merge_artifacts(inputs)`
+3. **Control flow**
+   - linear chains
+   - branch fan-out and joins
+   - `foreach`, `self.input`, `self.index`
+   - conditional branching
+   - recursion or re-entry patterns
+4. **Parameters and external inputs**
+   - `Parameter`
+   - `IncludeFile`
+   - `Config`
+   - CLI-time or deployment-time overrides
+5. **Decorators**
+   - `@retry`
+   - `@catch`
+   - `@timeout`
+   - `@resources`
+   - `@batch`
+   - `@kubernetes`
+   - `@conda`, `@pypi`, `@conda_base`
+   - `@environment`
+   - `@secrets`
+   - `@card`
+   - `@schedule`
+   - `@trigger`, `@trigger_on_finish`
+   - `@project`
+   - `@checkpoint`
+   - custom decorators or `--with <decorator>` overlays
+6. **Runtime and platform features**
+   - `current`
+   - `metaflow.client`
+   - `Runner`
+   - `Deployer`
+   - `resume`
+   - `metaflow.S3`
+   - namespaces and tags
+7. **Outerbounds features**
+   - Fast Bakery / dependency baking
+   - `@docker`
+   - `@gpu_profile`
+   - project assets
+   - deployment endpoints
+
+If the user gives you only a quick conceptual question, answer from the concept map and stop there. Use the full migration workflow only when there is real code or a real migration design problem to solve.
+
+### Phase 2: Classify and Plan
+
+For each pattern from Phase 1, classify it as direct, approximate, or absent. Use the quick guide below plus the detailed tables in [references/concept-map.md](references/concept-map.md) and [references/gaps-and-flags.md](references/gaps-and-flags.md).
+
+#### Quick classification guide
+
+**Direct translations (translate automatically):**
+- linear `self.next(self.a)` chains
+- simple `@step` method logic -> ZenML `@step`
+- simple `Parameter` values -> pipeline parameters
+- `@retry` -> `StepRetryConfig`
+
+**Approximate translations (translate with caveats):**
+- `FlowSpec` -> `@pipeline`
+- `self.*` artifacts -> explicit step returns and downstream inputs
+- branching + join -> explicit reducer/join steps
+- `foreach` -> `@pipeline(dynamic=True)` plus `.map()` and explicit reducer/join steps; manual loops may also need `.load()` for decisions and `.chunk(idx)` for DAG wiring
+- `@resources` -> `ResourceSettings`
+- `@kubernetes` -> Kubernetes orchestrator or step operator settings
+- `@conda` / `@pypi` / Fast Bakery -> `DockerSettings` and container-image design
+- `@schedule` -> `Schedule(...)`, with target orchestrator support and cron semantics called out explicitly
+- dynamic-pipeline-heavy flows -> only treat as a realistic target when the chosen orchestrator is one of ZenML's documented dynamic-pipeline backends (`local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, `azureml`)
+- `Config` -> YAML config / `.with_options(config_file=...)`
+- `current` -> `get_step_context()` for narrow step/run metadata lookup only; broader `current.*` usage must be flagged
+- `metaflow.client` -> `zenml.client.Client` only for limited lineage/artifact lookup; richer history traversal should be flagged
+- Runner / Deployer flows -> snapshots, deployments, SDK or API-triggered runs
+
+**Absent / must flag for review:**
+- `@catch`
+- `merge_artifacts`
+- direct recursion as a workflow primitive
+- exact `resume` semantics
+- `@checkpoint`
+- `@batch` as a direct portable equivalent
+- portable `@timeout` semantics
+- `@trigger` / `@trigger_on_finish`
+- business logic that depends on rich `current.*` state
+- Outerbounds-only features with no clear ZenML surface
+
+#### Present the plan before coding
+
+Before writing migration code, summarize the flow like this:
+
+> "Here's what I found in your Metaflow flow:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with caveats): [list]
+> - **Needs redesign** (cannot be auto-migrated safely): [list with explanation]
+>
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain them concretely in story form: what the Metaflow flow currently does, where the behavior lives, why ZenML cannot preserve it directly, and what redesign path is most honest.
+
+### Phase 3: Generate ZenML Code
+
+Translate the Metaflow flow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── transform.py
+│   └── load.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Custom materializers if needed
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+Key rules:
+
+- one step per file in `steps/`
+- separate pipeline definition from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` should use `requires-python = ">=3.12"` and a current ZenML dependency appropriate for the target environment
+- always generate `configs/dev.yaml` and `configs/prod.yaml`
+- always generate a `README.md` that explains what changed, how to run, and what still needs manual attention
+- include a brief ASCII DAG diagram in the pipeline module docstring
+- run `zenml init` at the project root
+
+#### Translation patterns
+
+For each Metaflow step, apply the right translation. See [references/code-patterns.md](references/code-patterns.md) for side-by-side examples.
+
+**Core rule:** move step logic out of the `FlowSpec` class and into standalone `@step` functions. Replace implicit `self.*` state with explicit function returns and typed inputs.
+
+```python
+# Metaflow
+class MyFlow(FlowSpec):
+    @step
+    def start(self):
+        self.x = 1
+        self.next(self.end)
+
+# ZenML
+@step
+def start() -> int:
+    return 1
+
+@step
+def end(x: int) -> None:
+    print(x)
+
+@pipeline
+def my_pipeline() -> None:
+    x = start()
+    end(x)
+```
+
+**`self.*` artifacts -> explicit artifacts**:
+
+```python
+# Metaflow
+self.features = build_features(self.raw)
+
+# ZenML
+@step
+def build_features_step(raw: list[int]) -> list[int]:
+    return build_features(raw)
+```
+
+**Parameters -> pipeline parameters**:
+
+```python
+# Metaflow
+class TrainFlow(FlowSpec):
+    alpha = Parameter("alpha", default=0.1)
+
+# ZenML
+@pipeline
+def train_pipeline(alpha: float = 0.1) -> None:
+    ...
+```
+
+**Retries -> `StepRetryConfig`**:
+
+```python
+@step(retry=StepRetryConfig(max_retries=3, delay=60, backoff=2))
+def flaky_step() -> None:
+    ...
+```
+
+**Scheduling -> `Schedule(...)`**:
+
+```python
+from zenml.config.schedule import Schedule
+
+schedule = Schedule(cron_expression="0 2 * * *")
+my_pipeline.with_options(schedule=schedule)()
+```
+
+Always note that scheduling support depends on the orchestrator. Check the scheduling table in [references/concept-map.md](references/concept-map.md).
+
+#### Handling approximate translations
+
+When a pattern is close but not identical, keep the generated code honest with short inline comments:
+
+```python
+@step
+def join_results(left_score: float, right_score: float) -> float:
+    # Migration note: Metaflow join steps can rely on implicit artifact
+    # propagation. ZenML requires the join contract to be explicit, so all
+    # branch outputs needed downstream are listed here directly.
+    return max(left_score, right_score)
+```
+
+Approximation comments should be short and actionable. Put the long explanation in the migration report, not in the code.
+
+#### Handling absent patterns
+
+Never silently approximate absent patterns. Instead:
+
+1. add a `# TODO(migration):` comment in the generated code
+2. record it in the migration report
+3. suggest a redesign
+
+```python
+# TODO(migration): UNSUPPORTED -- original flow used @catch to convert step
+# failure into a successful downstream continuation path. ZenML has no direct
+# equivalent. Consider returning an explicit Result/Error envelope from the step
+# or splitting the recovery logic into a separate pipeline.
+@step
+def recovery_wrapper(...) -> ...:
+    ...
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root:
+
+```markdown
+# Migration Report: [Metaflow Flow] -> [ZenML Pipeline]
+
+## Summary
+- **Source**: Metaflow flow `[FlowSpec name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Steps migrated**: X direct, Y approximate, Z flagged
+
+## Direct Translations
+| Metaflow Pattern | ZenML Equivalent | Notes |
+|---|---|---|
+| `@retry` on `train` | `StepRetryConfig` | Clean translation |
+
+## Approximate Translations
+| Metaflow Pattern | ZenML Equivalent | What Changed |
+|---|---|---|
+| `self.features` artifact propagation | explicit step outputs | downstream dependencies are now explicit |
+| `foreach` fan-out | dynamic pipeline `.map()` | experimental and orchestrator-limited |
+
+## Flagged for Review
+| Metaflow Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| `@catch` on `score_model` | HIGH | no direct placeholder-success behavior | return explicit error envelope |
+| `merge_artifacts(inputs)` | HIGH | no implicit merge primitive | write explicit conflict resolution logic |
+
+## Control-Flow Redesign Notes
+[Explain branch/join, foreach, conditionals, or recursion changes.]
+
+## Environment and Compute Mapping
+[Explain dependency, Docker, step-operator, and resource changes.]
+
+## Resume and Recovery Semantics
+- **Original**: [How resume/checkpoint behaved in Metaflow]
+- **Migrated**: [How caching/artifact reuse behaves in ZenML]
+- **Important difference**: [Why this is approximate, not exact]
+
+## What's NOT Migrated
+[List unsupported decorators, platform features, or manual follow-ups.]
+
+## What You Get for Free After Migration
+- typed, versioned artifacts
+- lineage and caching
+- stack abstraction
+- Model Control Plane
+- service connectors
+- pipeline deployments
+
+## Recommended Next Steps
+1. Run `zenml-quick-wins`
+2. Install the ZenML docs MCP server
+3. Review the flagged redesign items
+4. Use `zenml-pipeline-authoring` for deeper customization
+```
+
+Always include the "Resume and Recovery Semantics" section when the source flow used `resume`, `@checkpoint`, `@catch`, or complex retry behavior.
+
+### Phase 5: Suggest Next Steps
+
+After migration, always include a next-steps section in the report and summarize it to the user.
+
+#### 1. Run `zenml-quick-wins`
+
+Always suggest this first:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerters, secrets, and other production features."
+
+#### 2. Point to official ZenML docs for flagged patterns
+
+Use current official ZenML docs when suggesting follow-up reading:
+
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- Scheduling: `https://docs.zenml.io/concepts/steps_and_pipelines/scheduling`
+- Materializers: `https://docs.zenml.io/concepts/artifacts/materializers`
+- Pipeline deployments: `https://docs.zenml.io/concepts/deployment`
+- Service connectors: `https://docs.zenml.io/concepts/service_connectors`
+- Stack components: `https://docs.zenml.io/concepts/stack_components`
+- Models / Model Control Plane: `https://docs.zenml.io/concepts/models`
+
+#### 3. Suggest the ZenML docs MCP server
+
+> "For easier doc-grounded help while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Offer community help for real migration blockers
+
+When there are **2 or more HIGH-severity flags**, generate a ready-to-send Slack message for `zenml.io/slack` that includes:
+
+- what flow is being migrated
+- which Metaflow features blocked a clean migration
+- the workaround already attempted
+- what the user wants help with
+
+#### 5. Offer a GitHub issue for genuine feature gaps
+
+If the migration surfaces a real missing ZenML capability, offer to open an issue on `zenml-io/zenml` with the blocked Metaflow pattern, the attempted workaround, and why the gap matters.
+
+#### 6. Suggest `/simplify`
+
+Always suggest running `/simplify` on the generated code after migration. Migration output often carries extra comments, duplicated plumbing, or defensive wrappers that can be cleaned up once the user has reviewed the semantics.
+
+#### 7. Suggest `zenml-pipeline-authoring`
+
+For deeper follow-up work, recommend `zenml-pipeline-authoring` for:
+
+- Docker and container settings
+- YAML configuration
+- materializers
+- step operators
+- deployments and serving
+
+## Important Behavioral Differences to Communicate
+
+These are the places where users most easily get surprised after a migration.
+
+### `self.*` artifacts != explicit step outputs
+
+Metaflow lets a step quietly create many persisted artifacts just by assigning to `self.<name>`. ZenML persists what you explicitly return. If you forget to return something in ZenML, the downstream step will not magically find it later.
+
+### Join semantics are explicit in ZenML
+
+Metaflow joins can inherit artifacts implicitly and resolve ambiguity with `merge_artifacts(inputs)`. ZenML has no equivalent "carry forward whatever is unambiguous" rule. The join contract has to be written out by hand.
+
+### Dynamic control flow is possible, but not the default
+
+Metaflow can decide graph shape at step runtime with `self.next(...)`. ZenML static pipelines decide structure when the pipeline function runs. Runtime-dependent branching and fan-out generally require `@pipeline(dynamic=True)`. As of the current docs, dynamic pipelines are supported on `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml`, but still carry important feature and runtime limitations that should be called out in the migration report.
+
+### Resume is not caching
+
+Metaflow `resume` works by step identity and prior run state. ZenML caching works by code, inputs, settings, and artifact lineage. They both help you avoid re-running work, but they are not semantic twins.
+
+### Environment management shifts from decorator-driven installs to container design
+
+Metaflow often expresses dependencies as decorators like `@conda`, `@pypi`, or Outerbounds baking workflows. ZenML expects you to think in terms of Docker images, stack components, and step runtime environments.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Keeping a `FlowSpec` class and sprinkling ZenML decorators on methods | ZenML steps should be standalone callables with explicit inputs/outputs | Extract step logic into functions and rebuild the DAG in a `@pipeline` |
+| Translating `self.*` to module-level mutable state | Loses artifact persistence and lineage | Return typed values from steps and pass them downstream explicitly |
+| Silently replacing `merge_artifacts(inputs)` with "take one branch" | Changes join behavior | Write explicit merge/conflict logic and flag it |
+| Rewriting `foreach` as a plain Python `for` loop without calling out the semantic change | Loses orchestrated fan-out, observability, and parallelism | Use dynamic pipelines where supported, or flag the redesign |
+| Pretending `@catch` is just `try/except` | Metaflow changes pipeline failure semantics | Return explicit error objects or redesign the failure boundary |
+| Treating `resume` as identical to ZenML caching | They decide reuse differently | Explain the difference in the migration report |
+| Mapping `@batch` directly to a generic remote stack | Hides real compute and orchestration differences | Flag as redesign and choose the target compute model explicitly |
+| Assuming `current.*` metadata always has a ZenML twin | ZenML context is narrower | Replace with explicit inputs, metadata logging, or step context where possible |
+| Copying Outerbounds deploy semantics decorator-for-decorator | The control plane is different | Treat deployment and serving as redesign work using ZenML deployments/model deployers |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- full concept mapping tables for Metaflow, ZenML, and common Outerbounds extensions
+- [references/code-patterns.md](references/code-patterns.md) -- side-by-side code translations for linear flows, joins, `foreach`, Parameters, IncludeFile, retries, compute, and runtime APIs
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- must-flag patterns, behavioral differences, decision tree, and migration refusal rules
+
+### ZenML documentation
+
+For questions beyond the migration surface itself, use the current ZenML documentation at https://docs.zenml.io.

--- a/skills/zenml-metaflow-migration/skills/metaflow-migration/references/code-patterns.md
+++ b/skills/zenml-metaflow-migration/skills/metaflow-migration/references/code-patterns.md
@@ -1,0 +1,711 @@
+# Code Translation Patterns
+
+Side-by-side Metaflow -> ZenML translations for the patterns that show up most often in real migrations. Each section includes the source pattern, a ZenML sketch, the key semantic differences, and a migration warning when a silent approximation would be dangerous.
+
+## Table of Contents
+
+- [Simple Linear Flow](#simple-linear-flow)
+- [Data Passing via `self` Attributes](#data-passing-via-self-attributes)
+- [Parameter Handling](#parameter-handling)
+- [IncludeFile and External Inputs](#includefile-and-external-inputs)
+- [Branch and Join](#branch-and-join)
+- [Foreach Fan-Out and Reduce](#foreach-fan-out-and-reduce)
+- [Retry, Catch, and Timeout](#retry-catch-and-timeout)
+- [Resources and Remote Compute](#resources-and-remote-compute)
+- [Environment and Dependency Management](#environment-and-dependency-management)
+- [Scheduling](#scheduling)
+- [Resume and Caching](#resume-and-caching)
+- [`current` Runtime Context](#current-runtime-context)
+- [Client API and Historical Lookups](#client-api-and-historical-lookups)
+
+---
+
+## Simple Linear Flow
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, step
+
+
+class LinearFlow(FlowSpec):
+    @step
+    def start(self):
+        self.x = 1
+        self.next(self.step_a)
+
+    @step
+    def step_a(self):
+        self.y = self.x + 1
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.y)
+
+
+if __name__ == "__main__":
+    LinearFlow()
+```
+
+### ZenML
+
+```python
+from typing import Annotated
+
+from zenml import pipeline, step
+
+
+@step
+def start() -> Annotated[int, "x"]:
+    return 1
+
+
+@step
+def step_a(x: int) -> Annotated[int, "y"]:
+    return x + 1
+
+
+@step
+def end(y: int) -> None:
+    print(y)
+
+
+@pipeline
+def linear_pipeline() -> None:
+    x = start()
+    y = step_a(x)
+    end(y)
+```
+
+**Key differences**
+- `FlowSpec` becomes a `@pipeline`.
+- `self.*` becomes explicit step outputs.
+- `start` and `end` are just names in ZenML, not reserved nodes.
+
+**Migration warning**
+- Do not translate `self.x` into mutable global state. In Metaflow it is persisted; in ZenML only returned values are persisted.
+
+---
+
+## Data Passing via `self` Attributes
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, step
+
+
+class FeaturesFlow(FlowSpec):
+    @step
+    def start(self):
+        self.raw = [1, 2, 3]
+        self.next(self.transform)
+
+    @step
+    def transform(self):
+        self.features = [x * 10 for x in self.raw]
+        self.count = len(self.features)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.features, self.count)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def load_raw() -> list[int]:
+    return [1, 2, 3]
+
+
+@step
+def transform(raw: list[int]) -> tuple[list[int], int]:
+    features = [x * 10 for x in raw]
+    return features, len(features)
+
+
+@step
+def end(features: list[int], count: int) -> None:
+    print(features, count)
+
+
+@pipeline
+def features_pipeline() -> None:
+    raw = load_raw()
+    features, count = transform(raw)
+    end(features, count)
+```
+
+**Key differences**
+- Metaflow can quietly create many artifacts in one step.
+- ZenML needs every persisted output to be returned explicitly.
+
+**Migration warning**
+- Audit every downstream `self.<name>` read before you choose the ZenML return signature. Missing one output changes behavior silently.
+
+---
+
+## Parameter Handling
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, Parameter, step
+
+
+class TrainFlow(FlowSpec):
+    alpha = Parameter("alpha", default=0.1)
+
+    @step
+    def start(self):
+        self.lr = self.alpha
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.lr)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def choose_lr(alpha: float) -> float:
+    return alpha
+
+
+@step
+def end(lr: float) -> None:
+    print(lr)
+
+
+@pipeline
+def train_pipeline(alpha: float = 0.1) -> None:
+    lr = choose_lr(alpha=alpha)
+    end(lr)
+```
+
+**Key differences**
+- Metaflow parameters are available across the flow as read-only state.
+- ZenML parameters enter through the pipeline signature and must be passed where needed.
+
+**Migration warning**
+- If the Metaflow flow reads a parameter in many steps, you need to wire it explicitly or bundle it into a config object.
+
+---
+
+## IncludeFile and External Inputs
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, IncludeFile, step
+
+
+class ConfigFlow(FlowSpec):
+    prompt = IncludeFile("prompt", default="prompt.txt")
+
+    @step
+    def start(self):
+        self.prompt_text = self.prompt
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.prompt_text[:20])
+```
+
+### ZenML
+
+```python
+from pathlib import Path
+
+from zenml import pipeline, step
+
+
+@step
+def ingest_prompt(path: str) -> str:
+    return Path(path).read_text()
+
+
+@step
+def end(prompt_text: str) -> None:
+    print(prompt_text[:20])
+
+
+@pipeline
+def config_pipeline(prompt_path: str = "prompt.txt") -> None:
+    prompt_text = ingest_prompt(prompt_path)
+    end(prompt_text)
+```
+
+**Key differences**
+- Metaflow `IncludeFile` makes file contents a built-in flow input.
+- ZenML expects explicit ingestion or external artifact registration.
+
+**Migration warning**
+- Be explicit about whether the file contents, the file path, or a registered external artifact is the true contract.
+
+---
+
+## Branch and Join
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, step
+
+
+class BranchFlow(FlowSpec):
+    @step
+    def start(self):
+        self.value = 5
+        self.next(self.left, self.right)
+
+    @step
+    def left(self):
+        self.score = self.value + 1
+        self.next(self.join)
+
+    @step
+    def right(self):
+        self.score = self.value + 10
+        self.next(self.join)
+
+    @step
+    def join(self, inputs):
+        self.best = max(inp.score for inp in inputs)
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.best)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def start() -> int:
+    return 5
+
+
+@step
+def left(value: int) -> int:
+    return value + 1
+
+
+@step
+def right(value: int) -> int:
+    return value + 10
+
+
+@step
+def join(left_score: int, right_score: int) -> int:
+    return max(left_score, right_score)
+
+
+@step
+def end(best: int) -> None:
+    print(best)
+
+
+@pipeline
+def branch_pipeline() -> None:
+    value = start()
+    left_score = left(value)
+    right_score = right(value)
+    best = join(left_score=left_score, right_score=right_score)
+    end(best)
+```
+
+**Key differences**
+- Metaflow join steps receive a special `inputs` object.
+- ZenML join steps must name every incoming branch artifact explicitly.
+
+**Migration warning**
+- If the original join relied on implicit propagation or `merge_artifacts(inputs)`, you must redesign the join contract instead of guessing.
+
+---
+
+## Foreach Fan-Out and Reduce
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, step
+
+
+class BatchFlow(FlowSpec):
+    @step
+    def start(self):
+        self.items = ["a", "b", "c"]
+        self.next(self.process, foreach="items")
+
+    @step
+    def process(self):
+        self.result = self.input.upper()
+        self.next(self.join)
+
+    @step
+    def join(self, inputs):
+        self.results = [inp.result for inp in inputs]
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(self.results)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+
+@step
+def list_items() -> list[str]:
+    return ["a", "b", "c"]
+
+
+@step
+def process_item(item: str) -> str:
+    return item.upper()
+
+
+@step
+def collect(results: list[str]) -> None:
+    print(results)
+
+
+@pipeline(dynamic=True)
+def batch_pipeline() -> None:
+    items = list_items()
+    processed = process_item.map(items)
+    collect(processed)
+```
+
+**Key differences**
+- Both express fan-out and reduction, but ZenML does it through dynamic pipelines.
+- The current docs list dynamic-pipeline support for `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml`.
+- When you manually loop in a dynamic pipeline, `.load()` is for making Python decisions and `.chunk(idx)` is for creating DAG edges to individual elements.
+
+**Migration warning**
+- Do not rewrite `foreach` as a plain local loop without telling the user. That changes observability, concurrency, and orchestration semantics.
+
+---
+
+## Retry, Catch, and Timeout
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, catch, retry, step, timeout
+
+
+class RobustFlow(FlowSpec):
+    @retry(times=3, minutes_between_retries=1)
+    @timeout(seconds=300)
+    @catch(var="error")
+    @step
+    def start(self):
+        risky_call()
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print(getattr(self, "error", None))
+```
+
+### ZenML
+
+```python
+from dataclasses import dataclass
+
+from zenml import pipeline, step
+from zenml.config.retry_config import StepRetryConfig
+
+
+@dataclass
+class StepResult:
+    ok: bool
+    error: str | None
+
+
+@step(retry=StepRetryConfig(max_retries=3, delay=60, backoff=2))
+def guarded_start() -> StepResult:
+    try:
+        risky_call()
+        return StepResult(ok=True, error=None)
+    except Exception as exc:  # noqa: BLE001
+        return StepResult(ok=False, error=str(exc))
+
+
+@step
+def end(result: StepResult) -> None:
+    print(result.error)
+
+
+@pipeline
+def robust_pipeline() -> None:
+    result = guarded_start()
+    end(result)
+```
+
+**Key differences**
+- Retry maps well.
+- `@catch` does **not**. You must model error-as-data explicitly if you want downstream continuation.
+- Timeout behavior is backend-specific in ZenML.
+
+**Migration warning**
+- Never claim `@catch` was preserved just because you added `try/except`. The failure semantics changed and must be documented.
+
+---
+
+## Resources and Remote Compute
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, kubernetes, resources, step
+
+
+class GpuFlow(FlowSpec):
+    @kubernetes(cpu=4, memory=16000)
+    @resources(gpu=1)
+    @step
+    def train(self):
+        train_model()
+        self.next(self.end)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config.resource_settings import ResourceSettings
+
+
+@step(
+    settings={
+        "resources": ResourceSettings(cpu_count=4, memory="16Gi", gpu_count=1),
+    }
+)
+def train() -> None:
+    train_model()
+
+
+@pipeline
+def gpu_pipeline() -> None:
+    train()
+```
+
+**Key differences**
+- Resource requests map by intent.
+- The actual execution backend is chosen through the stack and orchestrator/step-operator configuration.
+
+**Migration warning**
+- Treat `@batch` and backend-specific compute decorators as migration-design questions, not decorator swaps.
+
+---
+
+## Environment and Dependency Management
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, conda, environment, pypi, step
+
+
+class EnvFlow(FlowSpec):
+    @conda(libraries={"pandas": "2.2.0"})
+    @pypi(packages={"requests": "2.32.0"})
+    @environment(vars={"MODE": "prod"})
+    @step
+    def start(self):
+        ...
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config.docker_settings import DockerSettings
+
+
+docker_settings = DockerSettings(
+    requirements=["pandas==2.2.0", "requests==2.32.0"],
+    environment={"MODE": "prod"},
+)
+
+
+@step(settings={"docker": docker_settings})
+def start() -> None:
+    ...
+
+
+@pipeline(settings={"docker": docker_settings})
+def env_pipeline() -> None:
+    start()
+```
+
+**Key differences**
+- Metaflow often resolves environments per step.
+- ZenML models the runtime as a container/image design problem.
+
+**Migration warning**
+- Outerbounds Fast Bakery and Metaflow dependency decorators are often best translated at the image level, not step by step.
+
+---
+
+## Scheduling
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, schedule, step
+
+
+@schedule(cron="0 2 * * *")
+class DailyFlow(FlowSpec):
+    @step
+    def start(self):
+        ...
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config.schedule import Schedule
+
+
+@step
+def start() -> None:
+    ...
+
+
+@pipeline
+def daily_pipeline() -> None:
+    start()
+
+
+schedule = Schedule(cron_expression="0 2 * * *")
+daily_pipeline.with_options(schedule=schedule)()
+```
+
+**Key differences**
+- Both support scheduling.
+- In ZenML, scheduler support depends on the orchestrator.
+
+**Migration warning**
+- If the source deployment assumed scheduling was always available, call out the target orchestrator requirement explicitly.
+
+---
+
+## Resume and Caching
+
+### Metaflow
+
+```bash
+python my_flow.py resume
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+
+
+@pipeline(enable_cache=True)
+def cached_pipeline() -> None:
+    ...
+```
+
+**Key differences**
+- Metaflow `resume` reuses completed work from an interrupted or prior run by flow/task identity.
+- ZenML caching reuses step outputs based on code, inputs, settings, and lineage.
+
+**Migration warning**
+- Caching is only an approximation of resume. If the source flow depends on exact resume or checkpoint semantics, flag it for review.
+
+---
+
+## `current` Runtime Context
+
+### Metaflow
+
+```python
+from metaflow import FlowSpec, current, step
+
+
+class ContextFlow(FlowSpec):
+    @step
+    def start(self):
+        print(current.run_id, current.step_name)
+        self.next(self.end)
+```
+
+### ZenML
+
+```python
+from zenml import step
+from zenml.steps import get_step_context
+
+
+@step
+def start() -> None:
+    context = get_step_context()
+    print(context.pipeline_run.name, context.step_run.name)
+```
+
+**Key differences**
+- ZenML exposes runtime metadata, but the available fields are not a full replacement for `current.*`.
+
+**Migration warning**
+- If the flow logic depends on Metaflow-specific runtime metadata, make that dependency explicit in the migration report.
+
+---
+
+## Client API and Historical Lookups
+
+### Metaflow
+
+```python
+from metaflow import Flow, Run
+
+
+latest_run = Flow("TrainingFlow").latest_run
+artifact = latest_run["score"]["accuracy"].data
+```
+
+### ZenML
+
+```python
+from zenml.client import Client
+
+
+client = Client()
+pipeline_runs = client.list_pipeline_runs(size=1, sort_by="desc:created")
+latest_run = pipeline_runs.items[0]
+step_run = next(step for step in latest_run.step_runs.values() if step.name == "score")
+```
+
+**Key differences**
+- Both expose historical lineage.
+- The object graph and traversal APIs differ significantly.
+
+**Migration warning**
+- If the flow makes heavy runtime decisions based on historical runs, treat it as a design concern, not just an API translation exercise.

--- a/skills/zenml-metaflow-migration/skills/metaflow-migration/references/concept-map.md
+++ b/skills/zenml-metaflow-migration/skills/metaflow-migration/references/concept-map.md
@@ -1,0 +1,125 @@
+# Metaflow -> ZenML Concept Map
+
+Complete mapping of Metaflow concepts to their ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (similar intent but different semantics), or **absent** (no safe ZenML equivalent -- needs redesign).
+
+## Table of Contents
+
+- [Core Primitives](#core-primitives)
+- [Data Passing and Parameters](#data-passing-and-parameters)
+- [Control Flow](#control-flow)
+- [Decorators](#decorators)
+- [Infrastructure and Compute](#infrastructure-and-compute)
+- [Outerbounds Extensions](#outerbounds-extensions)
+- [Orchestrator Scheduling Support](#orchestrator-scheduling-support)
+
+## Core Primitives
+
+| Metaflow Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `FlowSpec` | `@pipeline`-decorated function | approximate | Metaflow graph structure lives in a class and transitions are expressed with `self.next(...)`; ZenML builds the DAG inside a pipeline function. |
+| `@step` on a `FlowSpec` method | `@step` on a standalone function | approximate | Same decorator name, different object model. Metaflow mutates `self`; ZenML consumes inputs and returns outputs. |
+| `self.next(...)` | Calling downstream steps in the pipeline function | approximate | Metaflow transitions are runtime graph declarations; ZenML is usually static unless using dynamic pipelines. |
+| Reserved `start` step | First invoked ZenML step | absent | ZenML has no reserved `start` node. |
+| Reserved `end` step | Final step(s) or pipeline exhaustion | absent | ZenML has no reserved `end` node. |
+| Run | Pipeline run | direct | Both persist run metadata and artifacts, but the object model differs. |
+| Task | Step run / mapped invocation | approximate | Metaflow exposes tasks explicitly, especially in `foreach`; ZenML mapped invocations are similar but not identical. |
+
+## Data Passing and Parameters
+
+| Metaflow Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `self.x = value` in a step | Step return value(s) | approximate | In Metaflow, assignment creates persisted artifacts automatically. In ZenML, only returned values become artifacts. |
+| Reading `self.x` downstream | Step input parameter | approximate | ZenML requires the dependency to be explicit in the function signature. |
+| Arbitrary Python artifact object | Typed artifact + materializer | approximate | ZenML serialization depends on type hints and materializers, not generic pickle-by-default behavior. |
+| `Parameter` | Pipeline parameter | approximate | Both represent run inputs, but ZenML parameters are explicitly passed and typically JSON-serializable. |
+| `JSONType` parameter | Dict/list pipeline parameter | direct | Both support structured JSON-like values. |
+| `IncludeFile` | Registered/external artifact or explicit file ingestion | approximate | No exact "read file contents into the flow as a built-in parameter" primitive. |
+| `Config` | YAML config, `.with_options(config_file=...)`, settings objects | approximate | Similar purpose, different abstraction and evaluation model. |
+| `current` | `get_step_context()` | approximate | ZenML exposes step/run context, but not the full Metaflow `current.*` surface. |
+| `metaflow.S3` | Artifact store + external artifacts + cloud SDKs | approximate | Same broad purpose, different APIs and lineage semantics. |
+| Namespaces | Tags, separate servers, or ZenML Pro workspaces/projects | approximate | Similar isolation intent, different control plane. |
+| Tags | Tags | approximate | Both support tagging; semantics and APIs differ. |
+
+## Control Flow
+
+| Metaflow Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Linear `self.next(self.a)` chain | Static pipeline composition | direct | Safest migration case. |
+| `self.next(self.left, self.right)` | Parallel downstream step calls + explicit join step | approximate | ZenML requires the join contract to be explicit. |
+| Join step `def join(self, inputs)` | Reducer/join step with explicit branch inputs | approximate | No special `inputs` object in ZenML. |
+| `merge_artifacts(inputs)` | No direct equivalent | absent | Must write explicit merge/conflict logic. |
+| `self.next(step, foreach="items")` | `@pipeline(dynamic=True)` + `.map()` | approximate | Similar intent, but dynamic pipelines are experimental and currently documented for `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml`. |
+| `self.input` | Mapped item input parameter | approximate | Pass the item explicitly into the mapped step. |
+| `self.index` | Explicit index carried in the mapped payload | approximate | ZenML has no implicit foreach index object. |
+| Conditional `self.next({...}, condition="x")` | Dynamic pipeline branching or explicit redesign | approximate | Runtime branching exists, but semantics differ, usually requires `.load()` for decisions, and the feature surface is narrower. |
+| Recursion | Redesign into dynamic orchestration or repeated pipeline runs | absent | No documented general recursion primitive in ZenML. |
+
+## Decorators
+
+| Metaflow Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@retry` | `StepRetryConfig(max_retries, delay, backoff)` | direct | Cleanest decorator mapping. |
+| `@catch` | Explicit result/error envelope, alternate path, or redesign | absent | No direct "treat failure as successful continuation" primitive. |
+| `@timeout` | Orchestrator-specific timeout config or in-step timeout logic | absent | No single portable core timeout decorator. |
+| `@resources` | `ResourceSettings(cpu_count, memory, gpu_count, ...)` | approximate | Intent maps well; enforcement varies by backend. |
+| `@conda` | `DockerSettings(requirements=..., parent_image=...)` | approximate | ZenML thinks in container images, not per-step Conda env creation. |
+| `@pypi` | `DockerSettings(requirements=[...])` | approximate | Similar dependency intent, different execution model. |
+| `@conda_base` | Pipeline-level `DockerSettings` | approximate | Shared dependency baseline at the pipeline level. |
+| `@batch` | No direct equivalent | absent | Choose a target compute platform explicitly; do not claim a portable mapping. |
+| `@kubernetes` | Kubernetes orchestrator or step operator settings | approximate | Similar destination, different control plane. |
+| `@environment` | Environment variables in Docker/runtime settings | approximate | Similar intent, different configuration surface. |
+| `@secrets` | ZenML secrets store + service connectors | approximate | Both manage credentials, but ZenML separates secrets from connector auth. |
+| `@card` | Metadata logging, artifact visualizations, dashboard views | absent | No direct card/report canvas equivalent. |
+| `@schedule` | `Schedule(...)` via `.with_options(schedule=...)` | direct | Scheduling exists, but support depends on orchestrator. |
+| `@trigger` | External eventing + deployment or API trigger | absent | No decorator-level event trigger primitive. |
+| `@trigger_on_finish` | External chaining / API-driven orchestration | absent | No direct built-in equivalent. |
+| `@project` | Tags or ZenML Pro projects/workspaces | approximate | Similar grouping intent, different semantics. |
+| `@checkpoint` | Explicit checkpoint artifacts or external durable storage | absent | No decorator-level equivalent for in-task recovery state. |
+| Custom decorators | Hooks, wrapper steps, helper libraries, custom components | approximate | Translate by intent, not by syntax. |
+
+## Infrastructure and Compute
+
+| Metaflow Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Local runtime | Local orchestrator / direct pipeline call | approximate | Metaflow local runs isolate steps in separate processes; ZenML local execution is usually in the active environment. |
+| `run --with kubernetes` | Use a Kubernetes-backed stack | approximate | Backend choice moves from CLI overlay to stack/runtime configuration. |
+| `run --with batch` | No direct equivalent | absent | Redesign to the chosen remote compute target. |
+| Step Functions / Argo deployment | Choose a ZenML orchestrator and deployment strategy | approximate | Similar operational goal, different deployment contract. |
+| Object-store datastore | Artifact store | approximate | Similar broad role, different data model and APIs. |
+| Metadata service / UI | ZenML server and dashboard | approximate | Similar observability goal, different object model. |
+| `metaflow.client` | `zenml.client.Client` | approximate | Both expose lineage and run history, but traversal differs. |
+| `Runner` | Direct pipeline invocation, SDK, CLI, snapshots | approximate | Similar programmatic execution intent. |
+| `Deployer` | Deployments, snapshots, SDK/REST run triggers | approximate | Similar operational niche, different abstractions. |
+| `resume` | Caching + explicit artifact/checkpoint reuse | approximate | Operationally similar, but not a semantic drop-in replacement. |
+| CLI `--with <decorator>` overlays | Code/config/stack settings | absent | No universal ZenML equivalent to "attach decorators from the CLI". |
+
+## Outerbounds Extensions
+
+| Outerbounds Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| One-command production deploy | ZenML stacks, schedules, snapshots, or deployments | approximate | Similar goal, different control plane. |
+| Fast Bakery | `DockerSettings`, image build settings, parent images | approximate | Same dependency-to-image story, different workflow. |
+| Outerbounds `@docker` | `DockerSettings(parent_image=..., dockerfile=...)` | approximate | Similar intent, different API. |
+| Compute pools / secure perimeters | Stack selection, step operators, service connectors | approximate | Infrastructure abstraction exists, but not as a single pool concept. |
+| `@gpu_profile` | No direct equivalent | absent | Use experiment tracking, metadata, or external profilers instead. |
+| Assets API / project assets | Artifacts + metadata + models | approximate | Similar storage intent, split across multiple ZenML concepts. |
+| Long-running deployments / endpoints | Pipeline deployments or model deployers | approximate | Similar capability class, different lifecycle model. |
+| Public `@model` decorator | No claimed mapping | absent | Do not invent a mapping unless the user provides concrete code and docs. |
+
+## Orchestrator Scheduling Support
+
+Check scheduling support before translating Metaflow schedules:
+
+| Orchestrator | Scheduling | Types Supported |
+|---|:---:|---|
+| Kubernetes | Yes | Cron |
+| Vertex | Yes | Cron |
+| SageMaker | Yes | Cron, Interval, One-time |
+| AzureML | Yes | Cron, Interval |
+| Airflow | Yes | Cron, Interval |
+| Kubeflow | Yes | Cron, Interval |
+| Databricks | Yes | Cron only |
+| Local / LocalDocker | No | -- |
+| SkyPilot | No | -- |
+
+Dynamic pipelines are also feature-limited by orchestrator. When a migration depends on `foreach` or runtime branching, call that out explicitly in the migration report. For manual dynamic loops, use `.load()` to make Python control-flow decisions and `.chunk(idx)` when you need to create DAG edges to individual elements instead of eagerly loading them.

--- a/skills/zenml-metaflow-migration/skills/metaflow-migration/references/gaps-and-flags.md
+++ b/skills/zenml-metaflow-migration/skills/metaflow-migration/references/gaps-and-flags.md
@@ -1,0 +1,271 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the Metaflow patterns that are most dangerous to silently approximate during migration -- the spots where the rewritten pipeline may still run while meaning something different.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Metaflow Equivalent](#zenml-features-with-no-metaflow-equivalent)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### `@catch`
+
+**What Metaflow does**: converts a failing step into a successful continuation point and can attach exception data to an artifact.
+
+**Why it matters**: this changes the pipeline's failure story. Downstream code may expect the flow to continue even when a step blew up.
+
+**ZenML gap**: no direct placeholder-success equivalent.
+
+**Redesign approaches**:
+- return an explicit result/error envelope from the step
+- split recovery into a separate pipeline
+- move notification behavior into hooks
+
+### `merge_artifacts(inputs)`
+
+**What Metaflow does**: resolves join-time ambiguity by pulling forward branch artifacts implicitly.
+
+**Why it matters**: naive rewrites tend to keep only one branch or guess a winner.
+
+**ZenML gap**: no implicit merge primitive.
+
+**Redesign approaches**:
+- write an explicit reducer/join step
+- list each incoming branch artifact intentionally
+- implement conflict resolution in code
+
+### `foreach` with runtime-shaped semantics
+
+**What Metaflow does**: dynamically fans out one task per item and preserves `self.input`, task identity, and join-time aggregation semantics.
+
+**Why it matters**: rewriting it as a plain Python loop loses orchestration semantics and often parallelism.
+
+**ZenML gap**: dynamic pipelines can express similar intent, but the semantics and support surface differ.
+
+**Redesign approaches**:
+- use `@pipeline(dynamic=True)` plus `.map()` when supported
+- the current docs list support on `local`, `local_docker`, `kubernetes`, `sagemaker`, `vertex`, and `azureml`
+- for manual loops, use `.load()` for control-flow decisions and `.chunk(idx)` for DAG wiring
+- if support is uncertain, flag the fan-out for redesign instead of pretending it is equivalent
+
+### Conditional branching based on runtime artifacts
+
+**What Metaflow does**: can route the graph based on values produced during the run.
+
+**Why it matters**: static ZenML pipelines cannot do this directly.
+
+**ZenML gap**: requires dynamic pipelines or redesign.
+
+**Redesign approaches**:
+- use dynamic pipelines only when the target stack supports them
+- otherwise refactor into separate pipelines or explicit orchestration logic
+
+### Recursion
+
+**What Metaflow does**: newer versions support recursive control-flow patterns.
+
+**Why it matters**: recursion changes graph shape and termination behavior.
+
+**ZenML gap**: no documented general recursion primitive.
+
+**Redesign approaches**:
+- move the loop outside the pipeline
+- run repeated pipelines from a controller process
+- redesign into iterative dynamic orchestration if truly appropriate
+
+### `resume` and `@checkpoint`
+
+**What Metaflow does**: lets users restart or recover work using run/task identity and checkpoint state.
+
+**Why it matters**: teams often depend on this for long-running training or brittle infrastructure.
+
+**ZenML gap**: caching and artifact reuse help, but they are not semantic equivalents.
+
+**Redesign approaches**:
+- model checkpoint state as explicit artifacts
+- persist intermediate outputs to durable storage
+- document the changed recovery behavior clearly
+
+### `@batch`
+
+**What Metaflow does**: sends work to AWS Batch with Batch-shaped compute semantics.
+
+**Why it matters**: compute placement, retry behavior, and runtime assumptions may be part of correctness or cost control.
+
+**ZenML gap**: no portable direct `@batch` equivalent.
+
+**Redesign approaches**:
+- choose the target runtime explicitly (Kubernetes, SageMaker, Databricks, etc.)
+- express resources and environment in stack/runtime settings
+
+### Portable `@timeout`
+
+**What Metaflow does**: applies timeout semantics at the decorator level.
+
+**Why it matters**: timeouts interact with retries and failure continuation.
+
+**ZenML gap**: timeout support is backend-specific, not a universal core primitive.
+
+**Redesign approaches**:
+- use backend-specific job/pod timeout settings
+- implement application-level timeout handling where needed
+
+### `@trigger` / `@trigger_on_finish`
+
+**What Metaflow does**: ties event-driven or flow-chaining behavior to the deployment model.
+
+**Why it matters**: the workflow may depend on event-driven orchestration, not just scheduled batch runs.
+
+**ZenML gap**: no direct decorator-level equivalent.
+
+**Redesign approaches**:
+- external eventing + pipeline deployment
+- API-triggered runs
+- CI/CD or message-bus orchestration
+
+### Business logic that depends on `current.*`
+
+**What Metaflow does**: exposes a broad runtime context surface.
+
+**Why it matters**: code may depend on metadata that does not exist in ZenML the same way.
+
+**ZenML gap**: step context is narrower.
+
+**Redesign approaches**:
+- replace runtime introspection with explicit parameters or metadata logging
+- compute needed metadata inside the pipeline contract
+
+### Outerbounds-only features
+
+**What Metaflow / Outerbounds does**: adds features like Fast Bakery, `@gpu_profile`, deployment endpoints, and assets APIs.
+
+**Why it matters**: users may think these are "just Metaflow".
+
+**ZenML gap**: the overlapping capabilities exist, but often under different abstractions.
+
+**Redesign approaches**:
+- classify each feature by intent
+- translate to stack/deployment/model concepts only when the behavior is genuinely similar
+- otherwise flag it as redesign work
+
+---
+
+## Behavioral Differences
+
+### Data passing: `self.*` vs explicit artifacts
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Artifact creation | implicit via `self.<name> = ...` | explicit via step returns |
+| Downstream access | instance attributes | function inputs |
+| Serialization model | pickle-like artifact persistence | materializer-driven typed artifacts |
+| Hidden dependency risk | high | lower, because dependencies must be named |
+
+### Execution model
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Workflow structure | `FlowSpec` + `self.next(...)` | `@pipeline` + step calls |
+| Local execution | per-step process isolation | usually same active environment unless remote runtime is used |
+| Dynamic graph shape | built into Metaflow model | opt-in via dynamic pipelines |
+| Join semantics | special join step behavior | explicit step contracts |
+
+### Environment management
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Dependency story | decorators like `@conda`, `@pypi`, Fast Bakery | Docker/image settings and stack runtime |
+| Backend selection | decorators and CLI overlays | active stack + runtime settings |
+| Secret injection | `@secrets` | secrets store + service connectors |
+
+### Compute management
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Resource expression | decorators such as `@resources`, `@batch`, `@kubernetes` | `ResourceSettings`, stack components, step operators |
+| Backend identity | often explicit in source code/decorators | often chosen by stack configuration |
+| Portability | depends on Metaflow runtime | depends on the target ZenML stack |
+
+### Artifact lifecycle and lineage
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Artifact naming | often derived from `self.*` | derived from step outputs and type information |
+| Lineage object model | Run / Step / Task / Artifact | Pipeline / Run / StepRun / ArtifactVersion / Model |
+| Visualization | cards and client inspection | dashboard, metadata, visualizations, models |
+
+### Resume vs caching
+
+| Aspect | Metaflow | ZenML |
+|---|---|---|
+| Reuse mechanism | resume/checkpoint by prior run/task state | cache/artifact reuse by code, inputs, settings, lineage |
+| Failure recovery story | explicit operational feature | partial approximation via caching and artifact design |
+| Safe to claim "equivalent"? | no | no |
+
+---
+
+## Migration Decision Tree
+
+Use this text-first decision procedure when classifying a Metaflow pattern:
+
+```text
+INPUT: flow pattern, decorator set, artifact usage, control-flow shape
+
+1. Is the flow linear and artifact dependencies are obvious?
+   - Yes -> translate directly to static ZenML pipeline
+   - No -> continue
+
+2. Does the flow branch and later join?
+   - Yes -> design an explicit join step
+   - If join relied on merge_artifacts(inputs) or broad implicit state -> FLAG HIGH
+
+3. Does the flow use foreach, runtime branching, or recursion?
+   - If yes and target stack supports dynamic pipelines -> translate approximately and note limitations
+   - If yes and support is uncertain -> FLAG HIGH and propose redesign
+
+4. Does the flow use @catch, @checkpoint, resume-heavy recovery, or @trigger*?
+   - Yes -> FLAG HIGH; do not claim equivalence
+
+5. Does the flow use platform decorators (@batch, @kubernetes, @conda, @pypi, Fast Bakery)?
+   - Translate by intent:
+     - dependencies -> DockerSettings
+     - resources -> ResourceSettings
+     - compute backend -> stack/runtime selection
+   - If the original behavior depended on a specific provider contract -> FLAG MEDIUM/HIGH
+
+6. Does the code depend on current.*, metaflow.client, Runner, or Deployer?
+   - If only metadata lookup -> approximate via ZenML Client or step context
+   - If control flow depends on these APIs -> FLAG for design review
+
+7. After classification:
+   - Direct only -> full auto-migration
+   - Some approximate, no high-severity blockers -> migrate with caveats
+   - Any high-severity blockers -> partial migration + migration report + redesign notes
+   - Two or more high-severity blockers -> also generate a community-help / Slack-ready message
+```
+
+---
+
+## ZenML Features with No Metaflow Equivalent
+
+Migration is not only about losses. ZenML also gives users capabilities that often need to be surfaced explicitly after the rewrite.
+
+| ZenML Feature | Why it matters after migration |
+|---|---|
+| Typed artifacts + materializers | Makes data contracts explicit and inspectable |
+| Artifact lineage | Easier to trace where data or models came from |
+| Step caching | Saves reruns when code and inputs have not changed |
+| Stack abstraction | Same pipeline code can move across local and cloud stacks |
+| Service connectors | Centralized auth for cloud resources |
+| Model Control Plane | Rich model/version organization beyond raw run artifacts |
+| Pipeline deployments | Turn pipelines into HTTP-triggered services |
+| Snapshots | Re-run immutable pipeline snapshots from the SDK, CLI, dashboard, or API |
+
+Use this section in the migration report as the "what you get for free" bridge: it helps the user understand not just what changed, but what became possible.

--- a/skills/zenml-prefect-migration/plugin.json
+++ b/skills/zenml-prefect-migration/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "zenml-prefect-migration",
+  "version": "1.0.0",
+  "description": "Migrate Prefect flows and workflows to idiomatic ZenML pipelines with concept mapping, dynamic-execution analysis, code translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "prefect",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration",
+    "flows"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-prefect-migration/skills/prefect-migration/SKILL.md
+++ b/skills/zenml-prefect-migration/skills/prefect-migration/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: prefect-to-zenml-migration
+description: >-
+  Migrate Prefect flows, tasks, and deployment patterns to idiomatic ZenML
+  pipelines. Handles concept mapping (`@flow`→`@pipeline`, `@task`→`@step`,
+  result persistence→artifacts), dynamic-execution analysis, code translation,
+  scheduling, retries, Blocks/secrets decomposition, and flags unsupported
+  patterns (`allow_failure()`, `return_state=True`, pause/suspend, global
+  concurrency, task-runner semantics) for human review. Use this skill whenever
+  the user mentions Prefect migration, converting Prefect flows, porting
+  workflows from Prefect, replacing Prefect with ZenML, or asks how a Prefect
+  concept maps to ZenML — even if they do not explicitly say "migrate". Also
+  use when they paste Prefect code and ask to make it work with ZenML, or when
+  they describe a workflow using Prefect terminology (`@flow`, `@task`,
+  `.submit()`, `.map()`, `State`, Blocks, Deployments, work pools, Automations)
+  in a ZenML context. If the user asks a quick conceptual question ("what is
+  the ZenML equivalent of a Prefect Block?"), answer it directly from the
+  concept map — no need to run the full migration workflow.
+---
+
+# Migrate Prefect to ZenML
+
+This skill translates Prefect flows into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing Prefect code, classifying each pattern, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project plus a migration report.
+
+## How migration works at a high level
+
+Prefect and ZenML look similar at first glance because both are Python-first and both decorate functions. But the execution story is different.
+
+- **Prefect** runs the flow body like regular Python at runtime. That means the flow can branch on task outputs, inspect states, submit new tasks dynamically, and use pause/suspend semantics while the run is already in progress.
+- **ZenML static pipelines** compile a DAG before steps run. Step outputs are versioned artifacts, not ordinary in-memory values available during pipeline construction.
+- **ZenML dynamic pipelines** recover part of Prefect's runtime flexibility, but they are still an approximation rather than a full state-model match. As of the current ZenML docs, dynamic pipelines are explicitly marked **experimental** and support only a subset of orchestrators.
+
+So migration is never just "rename `@flow` to `@pipeline`". The real job is to decide which Prefect behaviors:
+
+1. map cleanly,
+2. map with semantic differences, or
+3. require redesign.
+
+### The three mapping types
+
+Every Prefect concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean or near-clean mapping exists | Translate automatically |
+| **Approximate** | Similar concept exists, but behavior changes | Translate with caveats in the migration report |
+| **Absent** | No trustworthy ZenML equivalent | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the Prefect Code
+
+Ask the user for their Prefect flow files, deployment config, and any supporting modules. Read everything before writing code. For each workflow, identify:
+
+1. **Flows and tasks** — Which functions use `@flow` and `@task`? Are there nested flows or direct task calls?
+2. **Execution model** — Is the workflow shape known up front, or does it depend on runtime task outputs?
+3. **Dynamic control flow** — Any `if` / `for` logic that branches on task results, or any `.submit()` / `.map()` fan-out?
+4. **State handling** — Any `return_state=True`, manual `State` inspection, returning `Failed(...)`, or `allow_failure()`?
+5. **Concurrency model** — Which task runner is used (`ThreadPoolTaskRunner`, `ProcessPoolTaskRunner`, Dask, Ray)? Is correctness tied to that runner?
+6. **Caching and result persistence** — Any `cache_key_fn`, cache expiration, `persist_result`, custom serializers, or storage blocks?
+7. **Human-in-the-loop** — Any `pause_flow_run()` or `suspend_flow_run()` behavior?
+8. **Configuration** — Any Prefect Blocks, Variables, secrets, or `prefect.yaml` deployment config?
+9. **Deployment and automation** — Any Deployments, work pools, workers, schedules, Automations, or webhook/event triggers?
+10. **Transactions or rollback hooks** — Any `on_commit`, `on_rollback`, or other transactional semantics?
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it as direct / approximate / absent using the logic below and the full tables in [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+**Direct or near-direct translations (translate automatically):**
+- Simple `@task` → `@step`
+- Simple static `@flow` → `@pipeline`
+- Task return values used for data passing → artifact passing
+- Simple task retries → `StepRetryConfig`
+- Secret-only Blocks → ZenML secrets
+
+**Approximate translations (translate with caveats):**
+- `@flow` generally → `@pipeline` (execution model differs)
+- Nested flows → pipeline composition
+- `.submit()` / `.map()` → dynamic pipelines or orchestrator-driven parallelism
+- Blocks → split into secrets + service connectors + stack settings + YAML config
+- Deployments / work pools → schedules + orchestrator choice + runtime config
+- Simple cron-like schedules → `Schedule(...)` when the target orchestrator supports scheduling
+- Result persistence / serializers → artifacts + materializers
+- Flow/task hooks → ZenML hooks and alerters
+- Pause / suspend → dynamic waits, explicit approval steps, or split workflows
+
+**Absent / redesign-required patterns (flag for human review):**
+- `allow_failure()`
+- `return_state=True`
+- Manual `State` inspection or returning `Failed(...)`
+- Global concurrency limits and `rate_limit()`
+- Task-runner semantics relied on for correctness
+- Transactions / rollback hooks
+- Push work pools or tightly coupled Prefect Cloud control-plane logic
+- Custom cache keys / TTL where the business semantics depend on them
+
+#### Present the migration plan
+
+Before generating code, present a concrete summary:
+
+> "Here's what I found in your Prefect workflow:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work with caveats): [list]
+> - **Needs redesign** (cannot be trusted as an automatic migration): [list]
+>
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain them in plain language:
+
+- what the Prefect code currently does,
+- why ZenML cannot reproduce it directly, and
+- what the recommended redesign looks like.
+
+### Phase 3: Generate ZenML Code
+
+Translate the Prefect project into an idiomatic ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── transform.py
+│   └── load.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Custom materializers (if needed)
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+Key rules:
+- One step per file in `steps/`
+- Separate pipeline definition from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` with `zenml>=0.94.1` and `requires-python = ">=3.12"`
+- Always generate `configs/dev.yaml` and `configs/prod.yaml`
+- Always generate a `README.md` explaining what was migrated and what still needs manual attention
+- Run `zenml init` at project root
+
+#### Core translation rules
+
+See [references/code-patterns.md](references/code-patterns.md) for side-by-side examples.
+
+**1. Prefer static pipelines by default**
+
+A ZenML static pipeline is the safest default when the DAG shape is known before execution.
+
+**2. Use `@pipeline(dynamic=True)` only when the Prefect flow truly depends on runtime outputs**
+
+Dynamic pipelines are the closest ZenML equivalent for:
+- branching on step outputs,
+- runtime fan-out over same-run artifacts,
+- runtime-shaped workflows.
+
+But they are not a universal substitute for Prefect's state model. When dynamic pipelines are needed, call that out clearly in the migration report.
+
+**3. Treat failure/state features as a data-model redesign, not a scheduling trick**
+
+For `allow_failure()` and `return_state=True`, do **not** silently replace them with a global execution mode. Instead, redesign around explicit outputs such as:
+
+```python
+{"ok": bool, "value": ..., "error": str | None}
+```
+
+That makes the new behavior visible and testable.
+
+**4. Decompose Blocks by concern**
+
+Never migrate a Prefect Block wholesale into "just an env var". Split it by purpose:
+
+- **secret data** → ZenML secrets
+- **cloud/service credentials** → service connectors
+- **infrastructure config** → stack/orchestrator settings
+- **runtime config** → YAML or pipeline parameters
+
+**5. Keep migration comments short and explicit**
+
+Use:
+- `# Migration note:` for brief caveats
+- `# TODO(migration):` for unsupported or manual-attention items
+
+#### Handling approximate translations
+
+When an approximation is safe enough to generate, add a short inline comment:
+
+```python
+@step
+def load_secret(secret_name: str) -> str:
+    # Migration note: this was a Prefect Secret block. ZenML stores secrets
+    # separately from runtime config, so the lookup path and lifecycle differ.
+    ...
+```
+
+#### Handling absent patterns
+
+For patterns with no trustworthy ZenML equivalent:
+
+1. add a `# TODO(migration):` comment,
+2. record it in `MIGRATION_REPORT.md`,
+3. suggest a redesign.
+
+```python
+# TODO(migration): UNSUPPORTED — original Prefect flow used allow_failure().
+# ZenML does not provide dependency-level failure tolerance with the same
+# semantics. Redesign this edge using an explicit result envelope artifact.
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root.
+
+```markdown
+# Migration Report: [Prefect Flow] → [ZenML Pipeline]
+
+## Summary
+- **Source**: Prefect flow `[flow_name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Components migrated**: X direct, Y approximate, Z flagged
+
+## Direct Translations
+| Prefect Pattern | ZenML Equivalent | Notes |
+|---|---|---|
+| `@task` `extract_data` | `steps/extract_data.py` | Clean task→step translation |
+
+## Approximate Translations
+| Prefect Pattern | ZenML Equivalent | What Changed |
+|---|---|---|
+| Deployment schedule | `Schedule(...)` | Scheduling support depends on orchestrator |
+| Secret Block | ZenML secret | Config lives in a different system |
+
+## Flagged for Review
+| Prefect Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| `allow_failure()` | HIGH | No direct ZenML equivalent | Return explicit success/error artifact |
+| `pause_flow_run()` | HIGH | No drop-in pause/suspend state model | Use explicit approval/wait workflow |
+
+## Execution Model Changes
+- Was the original Prefect flow dynamic at runtime?
+- Did the migration stay static, or require `@pipeline(dynamic=True)`?
+- What behavior changed because ZenML compiles the DAG differently?
+
+## State / Failure Handling Changes
+- Which State-based patterns were removed or redesigned?
+- Were failures turned into explicit data artifacts?
+
+## Configuration and Deployment Mapping
+- Which Blocks became secrets?
+- Which became YAML config?
+- Which deployment/work-pool settings now live in orchestrator or stack config?
+
+## What's NOT Migrated
+[List stateful control-plane behavior, transactions, Cloud-only features, or other unsupported patterns.]
+
+## What You Get for Free After Migration
+- Artifact versioning and lineage
+- Step caching
+- Stack portability
+- Service connectors
+- Model Control Plane (where relevant)
+
+## Recommended Next Steps
+1. Run `zenml-quick-wins`
+2. Install the ZenML docs MCP server
+3. Review each flagged redesign item
+4. Use `zenml-pipeline-authoring` for Docker, YAML, custom materializers, or deployment details
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always communicate the next steps clearly.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+This should almost always be the next step:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerts, and other production features."
+
+#### 2. Include documentation links for flagged patterns
+
+For flagged items, link to the most relevant ZenML docs. Common links:
+
+- Execution model: `https://docs.zenml.io/concepts/steps_and_pipelines/execution`
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- Scheduling: `https://docs.zenml.io/concepts/steps_and_pipelines/scheduling`
+- Service connectors: `https://docs.zenml.io/concepts/service_connectors`
+- Secrets: `https://docs.zenml.io/concepts/secrets`
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML documentation while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Offer community support for hard migration gaps
+
+When there are 2+ HIGH-severity flags, generate a ready-to-post Slack message for `zenml.io/slack` that includes:
+
+- what is being migrated,
+- the unsupported Prefect patterns,
+- the redesigns already attempted,
+- and a clear ask for suggestions.
+
+Use this template:
+
+```markdown
+**Prefect → ZenML Migration Help**
+
+I'm migrating a Prefect workflow that uses [patterns]. The migration skill flagged these as needing redesign:
+
+1. **[Pattern]**: [brief description + small code snippet]
+   - Suggested workaround: [X]
+   - Why this matters: [what behavior would change]
+
+2. **[Pattern]**: [brief description + small code snippet]
+   - Suggested workaround: [Y]
+
+I'm looking for advice on whether there's a better ZenML pattern, a feature I'm missing, or an upcoming capability that would make this migration cleaner.
+```
+
+#### 5. Offer GitHub issues for genuine feature gaps
+
+If the migration exposes a real ZenML capability gap — not just "works differently", but a reusable missing feature — offer to open an issue on `zenml-io/zenml`.
+
+#### 6. Suggest running `/simplify`
+
+Migration often leaves verbose comments and slightly mechanical structure behind. Always suggest `/simplify` once the migration is functionally complete.
+
+#### 7. Recommend `zenml-pipeline-authoring` for deeper follow-up work
+
+Use `zenml-pipeline-authoring` for:
+- Docker settings
+- YAML config
+- custom materializers
+- pipeline deployment details
+
+## Important Behavioral Differences to Communicate
+
+### Dynamic Prefect execution ≠ static ZenML execution
+
+In Prefect, flow code can make orchestration decisions while the run is already happening. In ZenML static pipelines, the DAG is compiled first. That is the single most important migration difference.
+
+### Prefect State objects ≠ ZenML run/step status
+
+Prefect lets workflow code inspect and route on state objects. ZenML records run and step status, but the authoring model is not "pass around State objects and branch on them."
+
+### Prefect results ≠ ZenML artifacts
+
+Prefect results can be optionally persisted and configured with storage/serializers. ZenML step outputs are first-class, versioned artifacts by default.
+
+### Blocks ≠ one ZenML object
+
+Prefect Blocks combine multiple concerns. ZenML splits them across secrets, connectors, stack components, YAML config, and parameters.
+
+### Prefect Deployments ≠ ZenML pipeline deployments
+
+Prefect Deployments are batch-run configuration. ZenML pipeline deployments are long-running HTTP services. For scheduled batch runs, the closer ZenML concepts are usually schedules, orchestrators, and sometimes snapshots — not HTTP deployments.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it is wrong | What to do instead |
+|---|---|---|
+| Replacing `allow_failure()` with a global continue-on-failure mode | Changes dependency-level failure semantics | Redesign with explicit success/error artifacts |
+| Translating runtime branches into static `if` statements on step outputs | Static pipelines cannot branch on artifact values | Use dynamic pipelines or redesign |
+| Turning all Blocks into environment variables | Loses schema, discoverability, and concern separation | Split into secrets, connectors, stack config, YAML |
+| Treating Prefect Deployments as ZenML HTTP deployments | They solve different problems | Map scheduled batch execution to schedules/orchestrators |
+| Assuming Dask/Ray task-runner behavior survives automatically | Concurrency and isolation models differ | Re-evaluate infra and step boundaries explicitly |
+| Silently dropping `cache_key_fn` logic | Can change business semantics, not just performance | Flag and redesign caching explicitly |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) — Full concept mapping tables for Prefect primitives, states, concurrency, Blocks, deployments, and automation patterns
+- [references/code-patterns.md](references/code-patterns.md) — Side-by-side translations for common Prefect patterns and redesign examples for unsafe ones
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) — Must-flag patterns, behavioral differences, decision tree, and migration anti-patterns
+
+### ZenML documentation
+
+For topics beyond migration, query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-prefect-migration/skills/prefect-migration/references/code-patterns.md
+++ b/skills/zenml-prefect-migration/skills/prefect-migration/references/code-patterns.md
@@ -1,0 +1,423 @@
+# Code Translation Patterns
+
+Side-by-side Prefect → ZenML translations for the migration patterns that come up most often.
+
+## Table of Contents
+
+- [Simple Linear Flow](#simple-linear-flow)
+- [Dynamic Branching on Task Results](#dynamic-branching-on-task-results)
+- [Runtime Fan-out with `.submit()` / `.map()`](#runtime-fan-out-with-submit--map)
+- [Nested Flows](#nested-flows)
+- [Retries](#retries)
+- [Failure-as-Data Redesign](#failure-as-data-redesign)
+- [Blocks and Secrets](#blocks-and-secrets)
+- [Scheduling and Deployments](#scheduling-and-deployments)
+
+---
+
+## Simple Linear Flow
+
+### Prefect
+
+```python
+from prefect import flow, task
+
+@task
+def extract() -> list[int]:
+    return [1, 2, 3]
+
+@task
+def transform(xs: list[int]) -> list[int]:
+    return [x * 10 for x in xs]
+
+@task
+def load(xs: list[int]) -> None:
+    print(xs)
+
+@flow
+def etl() -> None:
+    load(transform(extract()))
+```
+
+### ZenML
+
+```python
+from typing import List
+from zenml import pipeline, step
+
+@step
+def extract() -> List[int]:
+    return [1, 2, 3]
+
+@step
+def transform(xs: List[int]) -> List[int]:
+    return [x * 10 for x in xs]
+
+@step
+def load(xs: List[int]) -> None:
+    print(xs)
+
+@pipeline
+def etl() -> None:
+    load(transform(extract()))
+```
+
+**Why this is safe**: the workflow shape is static and Prefect tasks are only being used for dataflow, not runtime orchestration tricks.
+
+---
+
+## Dynamic Branching on Task Results
+
+### Prefect
+
+```python
+from prefect import flow, task
+
+@task
+def score(text: str) -> int:
+    return len(text)
+
+@task
+def long_path(text: str) -> None:
+    print(text.upper())
+
+@task
+def short_path(text: str) -> None:
+    print(text.lower())
+
+@flow
+def route(text: str) -> None:
+    s = score(text)
+    if s > 5:
+        long_path(text)
+    else:
+        short_path(text)
+```
+
+### ZenML static rewrite — only valid if the branch is really a parameter
+
+```python
+from zenml import pipeline, step
+
+@step
+def long_path(text: str) -> None:
+    print(text.upper())
+
+@step
+def short_path(text: str) -> None:
+    print(text.lower())
+
+@pipeline
+def route(text: str, use_long_path: bool) -> None:
+    if use_long_path:
+        long_path(text)
+    else:
+        short_path(text)
+```
+
+### ZenML dynamic rewrite — when the branch truly depends on a step output
+
+```python
+from zenml import pipeline, step
+
+@step
+def score(text: str) -> int:
+    return len(text)
+
+@step
+def long_path(text: str) -> None:
+    print(text.upper())
+
+@step
+def short_path(text: str) -> None:
+    print(text.lower())
+
+@pipeline(dynamic=True)
+def route(text: str) -> None:
+    decision = score(text)
+    if decision.load() > 5:
+        long_path(text)
+    else:
+        short_path(text)
+```
+
+**Migration warning**: if the original Prefect flow relied on runtime branching, do not silently downgrade it to a static parameter branch.
+
+---
+
+## Runtime Fan-out with `.submit()` / `.map()`
+
+### Prefect
+
+```python
+from prefect import flow, task
+from prefect.task_runners import ThreadPoolTaskRunner
+
+@task
+def discover_files() -> list[str]:
+    return ["a.csv", "b.csv", "c.csv"]
+
+@task
+def process_file(path: str) -> str:
+    return path.upper()
+
+@task
+def summarize(items: list[str]) -> None:
+    print(items)
+
+@flow(task_runner=ThreadPoolTaskRunner(max_workers=4))
+def batch_flow() -> None:
+    files = discover_files()
+    futures = [process_file.submit(path) for path in files]
+    summarize([f.result() for f in futures])
+```
+
+### ZenML dynamic pipeline
+
+```python
+from typing import List
+from zenml import pipeline, step
+
+@step
+def discover_files() -> List[str]:
+    return ["a.csv", "b.csv", "c.csv"]
+
+@step
+def process_file(path: str) -> str:
+    return path.upper()
+
+@step
+def summarize(items: List[str]) -> None:
+    print(items)
+
+@pipeline(dynamic=True)
+def batch_flow() -> None:
+    files = discover_files()
+    processed = process_file.map(files)
+    summarize(processed)
+```
+
+**Migration warning**: this preserves the fan-out shape, not the full Prefect task-runner semantics. If correctness depends on thread/process/Dask/Ray behavior, flag it for review.
+
+---
+
+## Nested Flows
+
+### Prefect
+
+```python
+from prefect import flow, task
+
+@task
+def prepare(x: int) -> int:
+    return x + 1
+
+@flow
+def child_flow(x: int) -> int:
+    return prepare(x)
+
+@flow
+def parent_flow(x: int) -> int:
+    return child_flow(x) * 2
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def prepare(x: int) -> int:
+    return x + 1
+
+def child_component(x: int):
+    return prepare(x)
+
+@step
+def double(x: int) -> int:
+    return x * 2
+
+@pipeline
+def parent_pipeline(x: int) -> None:
+    child_result = child_component(x)
+    double(child_result)
+```
+
+**Migration warning**: this preserves composition, not Prefect's nested flow-run tracking or child-flow state semantics.
+
+---
+
+## Retries
+
+### Prefect
+
+```python
+from prefect import flow, task
+
+@task(retries=3, retry_delay_seconds=10)
+def flaky() -> str:
+    ...
+
+@flow
+def train() -> str:
+    return flaky()
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.config.retry_config import StepRetryConfig
+
+RETRY = StepRetryConfig(max_retries=3, delay=10)
+
+@step(retry=RETRY)
+def flaky() -> str:
+    ...
+
+@pipeline
+def train() -> None:
+    flaky()
+```
+
+**Migration warning**: Prefect retry conditions, jitter, or state-aware retry logic may need more than a simple `StepRetryConfig`.
+
+---
+
+## Failure-as-Data Redesign
+
+Use this when the Prefect flow relied on `return_state=True` or `allow_failure()`.
+
+### Prefect
+
+```python
+from prefect import flow, task
+from prefect.utilities.annotations import allow_failure
+
+@task
+def might_fail(x: int) -> int:
+    if x < 0:
+        raise ValueError("negative")
+    return x * 2
+
+@task
+def inspect(result) -> str:
+    return str(result)
+
+@flow
+def f(x: int) -> str:
+    state = might_fail.submit(x, return_state=True)
+    return inspect.submit(allow_failure(state)).result()
+```
+
+### ZenML redesign
+
+```python
+from typing import Any, Dict
+from zenml import pipeline, step
+
+@step
+def might_fail(x: int) -> Dict[str, Any]:
+    try:
+        if x < 0:
+            raise ValueError("negative")
+        return {"ok": True, "value": x * 2, "error": None}
+    except Exception as exc:  # replace with narrower exception if known
+        return {"ok": False, "value": None, "error": str(exc)}
+
+@step
+def inspect(result: Dict[str, Any]) -> str:
+    if result["ok"]:
+        return f"value={result['value']}"
+    return f"error={result['error']}"
+
+@pipeline
+def f(x: int) -> None:
+    inspect(might_fail(x))
+```
+
+**Migration warning**: this is a redesign, not a direct translation. The point is to make failure handling explicit in the data model.
+
+---
+
+## Blocks and Secrets
+
+### Prefect
+
+```python
+from prefect import flow, task
+from prefect.blocks.system import Secret
+
+@task
+def call_api() -> None:
+    token = Secret.load("api-token").get()
+    print(token[:3])
+
+@flow
+def api_flow() -> None:
+    call_api()
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+from zenml.client import Client
+
+@step
+def call_api(secret_name: str = "api-token") -> None:
+    secret = Client().get_secret(secret_name)
+    # Migration note: this example assumes the ZenML secret stores a field
+    # named `token`. If the original Prefect block held a different schema,
+    # migrate that schema explicitly instead of guessing.
+    token = secret.secret_values["token"]
+    print(token[:3])
+
+@pipeline
+def api_flow() -> None:
+    call_api()
+```
+
+**Migration warning**: a Prefect Block may also carry schema, methods, or mixed config. Secret-only blocks migrate cleanly; richer blocks should be decomposed.
+
+---
+
+## Scheduling and Deployments
+
+### Prefect
+
+```python
+from prefect import flow
+
+@flow
+def daily_flow(customer: str = "acme") -> None:
+    ...
+
+if __name__ == "__main__":
+    daily_flow.deploy(
+        name="daily-acme",
+        work_pool_name="k8s-pool",
+        cron="0 2 * * *",
+        parameters={"customer": "acme"},
+    )
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+from zenml.config.schedule import Schedule
+
+@pipeline
+def daily_flow(customer: str = "acme") -> None:
+    ...
+
+schedule = Schedule(cron_expression="0 2 * * *")
+daily_flow = daily_flow.with_options(schedule=schedule)
+daily_flow(customer="acme")
+```
+
+**Migration warning**:
+- Prefect Deployment ≠ ZenML pipeline deployment.
+- Work pools do not have a 1:1 ZenML OSS equivalent.
+- The actual migration target is usually: schedule + orchestrator + YAML/runtime config.

--- a/skills/zenml-prefect-migration/skills/prefect-migration/references/concept-map.md
+++ b/skills/zenml-prefect-migration/skills/prefect-migration/references/concept-map.md
@@ -1,0 +1,113 @@
+# Prefect → ZenML Concept Map
+
+Complete mapping of Prefect concepts to their ZenML equivalents. Each entry is classified as **direct**, **approximate**, or **absent**.
+
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [State Handling](#state-handling)
+- [Execution and Concurrency](#execution-and-concurrency)
+- [Data, Results, and Caching](#data-results-and-caching)
+- [Configuration and Secrets](#configuration-and-secrets)
+- [Deployment and Automation](#deployment-and-automation)
+- [Orchestrator Scheduling Support](#orchestrator-scheduling-support)
+
+## Core Concepts
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@flow` | `@pipeline` | approximate | Both decorate Python callables, but Prefect flow bodies execute imperatively while ZenML static pipelines compile a DAG first. |
+| `@task` | `@step` | direct | This is the cleanest migration path. |
+| Direct task call inside flow | Step call inside pipeline | approximate | Code shape looks similar, but Prefect executes now while ZenML is composing the graph. |
+| Nested flow / subflow | Pipeline composition | approximate | Structural reuse maps well; child-run/state semantics do not. |
+| Flow return value | Pipeline outputs / artifacts | approximate | ZenML centers on artifacts and run metadata rather than an ordinary Python return flow. |
+| `flow_run_name` | `with_options(run_name=...)` | approximate | Similar user-facing intent, different lifecycle semantics. |
+| Flow timeout | Orchestrator/job timeout settings | approximate | Timeout lives in different places depending on ZenML stack/orchestrator. |
+
+## State Handling
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `State` object | No first-class in-pipeline state object | absent | ZenML has run/step statuses, not an inspectable `State` passed through workflow code. |
+| `Completed`, `Failed`, `Paused`, `Suspended`, `Cancelled`, etc. | Run/step execution status | approximate | Status exists in both systems, but the programmatic model is much richer in Prefect. |
+| `return_state=True` | None | absent | Requires redesign. |
+| Returning `Failed(...)` manually | Exception or explicit failure-as-data artifact | approximate | Usually redesign around explicit outputs instead of hidden state semantics. |
+| `allow_failure()` | None | absent | No dependency-level equivalent in ZenML. |
+| `on_completion`, `on_failure` | `on_success`, `on_failure` hooks | approximate | Hook model exists, but semantics and context differ. |
+| `pause_flow_run()` | Dynamic wait / approval pattern / split workflow | approximate | Partial substitute only; not a drop-in orchestration-state match. |
+| `suspend_flow_run()` | Dynamic wait + resume-compatible setup / split workflow | approximate / absent | Often redesign-required for durable resume semantics. |
+
+## Execution and Concurrency
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Static flow code | Static pipeline | approximate | Safe only when workflow shape is known before execution. |
+| Runtime branch on task output | `@pipeline(dynamic=True)` | approximate | Closest equivalent, but dynamic pipelines are still experimental and have limits. |
+| `.submit()` | `step.submit()` in dynamic pipelines | approximate | Similar concurrency intent; failure handling differs. |
+| `.map()` | `step.map()` in dynamic pipelines | approximate | Same-run artifact limitation and different orchestration semantics. |
+| `ThreadPoolTaskRunner` | Dynamic `runtime="inline"` or orchestrator concurrency | approximate | Similar concurrency goal, different abstraction. |
+| `ProcessPoolTaskRunner` | `runtime="isolated"` or isolated step execution | approximate | Similar isolation goal, different execution model. |
+| `DaskTaskRunner` / `RayTaskRunner` | Run Dask/Ray inside a step or re-architect infra | approximate | No native ZenML task-runner analogue. |
+| `wait_for=` dependency-only ordering | `after=` / explicit dependency | direct | One of the cleanest execution-control mappings. |
+| Global `concurrency("name")` | None | absent | Must redesign with external locking or platform controls. |
+| `rate_limit("name")` | None | absent | Must redesign with external quota or serialized logic. |
+| Deployment/work-pool concurrency limit | Orchestrator or job concurrency controls | approximate | Operational goal overlaps, but API/scope differ. |
+
+## Data, Results, and Caching
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Task/flow result | Artifact output | approximate | Both persist outputs, but artifacts are central in ZenML. |
+| `persist_result=True` | Default artifact persistence | approximate | Similar intent, different default model and storage lifecycle. |
+| `result_storage` | Artifact store | approximate | Same broad concern, different abstraction boundary. |
+| `result_serializer` | Materializer | approximate | Closest equivalent. |
+| `result_storage_key` | Artifact naming / URI / versioning | approximate | No exact 1:1 field. |
+| Step caching | Step caching | approximate | Both have reuse semantics, but triggers/configuration differ. |
+| `cache_key_fn` | None | absent | Custom cache-key callbacks do not have a direct ZenML equivalent. |
+| Cache expiration / TTL | No exact equivalent | absent / approximate | Flag when business logic depends on the TTL itself. |
+| Human-facing Prefect artifacts | ZenML artifacts / reports / dashboard metadata | approximate | Different UI and data model emphasis. |
+
+## Configuration and Secrets
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Block system overall | Secrets + service connectors + stack config + YAML + params | approximate | Must split by concern; there is no single equivalent. |
+| Secret Block | ZenML secret | direct | Closest clean mapping. |
+| Typed config Block | YAML config / Pydantic config / stack settings | approximate | Same purpose, different storage/distribution model. |
+| Service/auth Block | Service connector | approximate | Best mapping for cloud credentials and auth intent. |
+| Variable | YAML config / pipeline parameters / secrets | approximate | Prefer explicit typing and separate secret handling. |
+| `prefect.yaml` | ZenML YAML configuration | approximate | Similar configuration role, different schema and runtime contract. |
+| Custom Block | Custom config model + secrets + infra config | approximate | Usually needs decomposition and redesign. |
+
+## Deployment and Automation
+
+| Prefect Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Deployment | Schedule + orchestrator + run config + sometimes snapshots | approximate | Map by intent, not by name. |
+| `flow.serve()` | Local scheduled execution / deployment registration pattern | approximate | Similar convenience, different implementation model. |
+| Work pool | Orchestrator / stack / execution backend | approximate | No single work-pool routing abstraction in ZenML OSS. |
+| Process work pool | Local orchestrator | approximate | Similar local execution goal. |
+| Docker work pool | LocalDocker / containerized orchestrator path | approximate | Similar environment shape, different control plane. |
+| Kubernetes work pool | Kubernetes orchestrator | approximate | Closest clean infrastructure mapping. |
+| Vertex work pool | Vertex orchestrator | approximate | Similar remote managed execution goal. |
+| Push / managed work pools | None direct | absent / approximate | Usually needs external platform or ZenML Pro-specific redesign. |
+| Worker | Orchestrator execution environment | approximate | Operationally similar, not the same API/control-plane concept. |
+| Automations | ZenML Pro triggers or external automation | approximate / absent | No direct OSS counterpart. |
+| Event-driven triggers | External eventing / triggers / webhooks | approximate | Depends on stack and product tier. |
+| Pipeline deployment (ZenML) | No true Prefect equivalent | absent | ZenML pipeline deployments are HTTP services, not batch-run deployment configs. |
+
+## Orchestrator Scheduling Support
+
+Not all ZenML orchestrators support schedules. Check the target stack before claiming a clean schedule migration.
+
+| Orchestrator | Scheduling Support | Types Supported |
+|---|:---:|---|
+| Kubernetes | Yes | Cron |
+| Vertex | Yes | Cron |
+| SageMaker | Yes | Cron, Interval, One-time |
+| AzureML | Yes | Cron, Interval |
+| Airflow (as ZenML orchestrator) | Yes | Cron, Interval |
+| Kubeflow | Yes | Cron, Interval |
+| Databricks | Yes | Cron only |
+| Local / LocalDocker | No | — |
+| SkyPilot | No | — |

--- a/skills/zenml-prefect-migration/skills/prefect-migration/references/gaps-and-flags.md
+++ b/skills/zenml-prefect-migration/skills/prefect-migration/references/gaps-and-flags.md
@@ -1,0 +1,235 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the Prefect patterns that are most dangerous to silently approximate during migration.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Prefect Equivalent](#zenml-features-with-no-prefect-equivalent)
+- [Anti-Patterns in Migration](#anti-patterns-in-migration)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### Branching on runtime task outputs
+
+**What Prefect does**: the flow can branch on a task result as ordinary Python because the flow body is executing imperatively.
+
+**Why it matters**: a static ZenML pipeline cannot branch on artifact values while compiling the DAG.
+
+**Migration options**:
+- use `@pipeline(dynamic=True)` if the target stack supports it,
+- redesign the branch to depend on pipeline parameters,
+- or split the workflow into multiple pipelines.
+
+### Runtime fan-out from `.submit()` / `.map()`
+
+**What Prefect does**: task runners can create concurrent task executions based on runtime-discovered items.
+
+**Why it matters**: ZenML dynamic pipelines can approximate this, but the execution semantics are different and support is narrower.
+
+**Migration options**:
+- use dynamic pipelines with `.map()` when same-run artifacts and orchestrator support line up,
+- or redesign into multi-run orchestration / batch-inside-a-step.
+
+**Important caveat**: dynamic pipelines are the closest escape hatch here, but they come with real limits. The current ZenML docs describe them as experimental, with limited orchestrator support and tighter execution-mode/failure-handling behavior than standard static pipelines. Surface those caveats before presenting a fan-out migration as "safe".
+
+### `return_state=True`
+
+**What Prefect does**: returns a terminal `State` instead of raising immediately.
+
+**Why it matters**: ZenML does not use inspectable State objects as a first-class authoring primitive.
+
+**Migration options**:
+- redesign around explicit result envelopes,
+- or move the inspection logic outside the pipeline.
+
+### `allow_failure()`
+
+**What Prefect does**: allows a downstream task to accept a failed upstream input.
+
+**Why it matters**: ZenML has no dependency-level failure-tolerance feature with equivalent semantics.
+
+**Migration rule**: do **not** replace this with a global continue-on-failure switch. That changes behavior.
+
+### Manual State inspection and returned State objects
+
+Flag any workflow that:
+- inspects `.is_failed()` / `.is_completed()` or state types,
+- returns `Failed(...)` / `Completed(...)` manually,
+- branches on a `State` rather than on ordinary business data.
+
+These patterns are dangerous because they turn Prefect's orchestration state into application control flow. ZenML does not expose a matching in-pipeline State object model.
+
+### Pause / suspend
+
+**What Prefect does**: can pause or suspend a flow run and later resume it.
+
+**Why it matters**: ZenML has partial waiting/approval patterns, but not the same durable orchestration-state model across all scenarios.
+
+**Migration options**:
+- explicit approval/wait steps,
+- external trigger-driven continuation,
+- split the workflow into separate pipelines.
+
+### Task-runner semantics
+
+Flag any workflow where correctness or cost assumptions depend on:
+- `ThreadPoolTaskRunner`
+- `ProcessPoolTaskRunner`
+- Dask / Ray task runners
+- shared in-process concurrency behavior
+
+These are not mere implementation details. They often shape the workflow's correctness, resource usage, or latency.
+
+### Global concurrency and rate limiting
+
+Flag any use of:
+- `concurrency("name")`
+- `rate_limit("name")`
+- tag-based limits
+- deployment/work-pool concurrency used for correctness
+
+Prefect's slot-based concurrency/rate-limit model has no direct ZenML OSS equivalent.
+
+### Caching with business semantics
+
+Flag:
+- `cache_key_fn`
+- cache expiration/TTL relied on for correctness
+- `refresh_cache` patterns that matter semantically
+
+ZenML caching is real, but it is not "user-provided cache keys with the same meaning."
+
+### Blocks, Deployments, and Automations used as a control plane
+
+Flag:
+- custom Blocks that mix secrets + runtime config + behavior,
+- work pools that encode routing/business behavior,
+- Automations that drive workflow logic,
+- Cloud-only deployment behavior that the code depends on.
+
+### Transactions and rollback hooks
+
+Flag:
+- transaction blocks,
+- `on_commit`,
+- `on_rollback`,
+- any workflow where rollback is a first-class requirement.
+
+This is redesign territory.
+
+---
+
+## Behavioral Differences
+
+These differences are important even when migration is possible.
+
+### Dynamic execution vs DAG compilation
+
+| Aspect | Prefect | ZenML |
+|---|---|---|
+| Workflow shape | Can evolve while the flow is running | Static pipelines compile the DAG before step execution |
+| Runtime branching | Native | Requires dynamic pipelines or redesign |
+| Runtime fan-out | Native with task runners | Requires dynamic pipelines or redesign |
+
+### State model
+
+| Aspect | Prefect | ZenML |
+|---|---|---|
+| State object | First-class and inspectable | No equivalent in-pipeline object |
+| Pause / suspend | Built into run state model | Partial wait/approval patterns only |
+| Continue after failed upstream | `allow_failure()` | No dependency-level equivalent |
+
+### Results vs artifacts
+
+| Aspect | Prefect | ZenML |
+|---|---|---|
+| Output model | Results can be optionally persisted | Step outputs are versioned artifacts |
+| Storage | Configurable result storage | Artifact store |
+| Serialization | Result serializers | Materializers |
+| Caching | Prefect task-state reuse | Artifact/code/input-based step caching |
+
+### Concurrency
+
+| Aspect | Prefect | ZenML |
+|---|---|---|
+| Primary parallelism model | Task runners inside a flow | Orchestrator/step execution model |
+| Global concurrency / rate limits | Built-in named slot system | No direct OSS equivalent |
+| Dask / Ray | First-class runner integrations | Usually embedded inside steps or re-architected |
+
+### Configuration and deployment model
+
+| Aspect | Prefect | ZenML |
+|---|---|---|
+| Typed config objects | Blocks | Split across secrets, connectors, stack config, YAML |
+| Deployment abstraction | Deployment + work pool + worker | Orchestrator + schedule + stack + runtime config |
+| Event-driven automation | Built-in Automations | External eventing or ZenML Pro-specific features |
+
+---
+
+## Migration Decision Tree
+
+Use this to classify a Prefect workflow systematically:
+
+```text
+1) Classify the flow shape
+   ├── Static, known before execution → prefer standard @pipeline
+   └── Depends on task outputs / runtime fan-out → consider @pipeline(dynamic=True)
+
+2) Check stateful control flow
+   ├── Uses return_state=True / manual State inspection / returned State objects → FLAG HIGH
+   ├── Uses allow_failure() → FLAG HIGH
+   └── Uses pause/suspend → FLAG HIGH
+
+3) Check concurrency semantics
+   ├── Plain sequential / simple retry → translate normally
+   ├── .submit() / .map() for throughput only → dynamic pipeline maybe OK
+   ├── Dask/Ray or runner semantics critical → FLAG HIGH
+   └── concurrency()/rate_limit() → FLAG HIGH
+
+4) Check config/deployment
+   ├── Secret-only Blocks → migrate to ZenML secrets
+   ├── Infra/auth Blocks → service connectors / stack config
+   ├── Deployments/work pools only for scheduling → approximate migration
+   └── Automations/work pools/Cloud control plane drive business logic → FLAG HIGH
+
+5) Decide
+   ├── No HIGH flags → full migration with notes
+   ├── Some HIGH flags but core path still useful → partial migration + redesign report
+   └── Workflow built around state/control-plane features → architectural redesign
+```
+
+---
+
+## ZenML Features with No Prefect Equivalent
+
+These are worth mentioning in the migration report as "what you get for free".
+
+| Feature | Value |
+|---|---|
+| **Artifact versioning and lineage** | Every step output is tracked as a first-class artifact. |
+| **Stack abstraction** | The same pipeline code can move across infrastructure by switching stacks. |
+| **Service connectors** | Standardized cloud auth and credential management. |
+| **Model Control Plane** | First-class model tracking and promotion workflows. |
+| **Pipeline deployments (HTTP services)** | Long-running pipeline-serving mode — a different capability, not a Prefect Deployment clone. |
+| **Strong artifact-centric reproducibility** | Inputs, outputs, and lineage are explicit and inspectable. |
+
+---
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Replace `allow_failure()` with a global continue-on-failure setting | Changes dependency semantics | Return explicit success/error artifacts |
+| Convert runtime branching to static `if` on step outputs | Static pipelines cannot do that safely | Use dynamic pipelines or redesign |
+| Assume `.submit()` / `.map()` preserve Prefect runner behavior | Parallelism model differs | Re-check correctness and infra assumptions |
+| Convert all Blocks into env vars | Loses schema and concern separation | Split into secrets, connectors, stack config, YAML |
+| Treat Prefect Deployment as ZenML pipeline deployment | They solve different problems | Map to schedules/orchestrators unless HTTP serving is truly needed |
+| Silently drop concurrency/rate limits | Can change correctness and overload external systems | Add explicit throttling or platform-level controls |
+| Ignore `cache_key_fn` | Can change business semantics | Flag and redesign cache behavior explicitly |

--- a/skills/zenml-sagemaker-migration/plugin.json
+++ b/skills/zenml-sagemaker-migration/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "zenml-sagemaker-migration",
+  "version": "1.0.0",
+  "description": "Migrate Amazon SageMaker Pipelines and workflow code to idiomatic ZenML pipelines with concept mapping, code translation, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "sagemaker",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration",
+    "aws"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-sagemaker-migration/skills/sagemaker-migration/SKILL.md
+++ b/skills/zenml-sagemaker-migration/skills/sagemaker-migration/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: sagemaker-to-zenml-migration
+description: >-
+  Migrate Amazon SageMaker Pipelines and workflow code to idiomatic ZenML
+  pipelines. Handles concept mapping (Pipeline->@pipeline,
+  ProcessingStep/TrainingStep->@step, PropertyFile/JsonGet->artifacts),
+  code translation, SagemakerOrchestratorSettings mapping, scheduling,
+  model-registration strategy, and flags unsupported or high-risk patterns
+  (CallbackStep, LambdaStep handshake semantics, step.properties placeholders,
+  dynamic-pipeline scheduling on SageMaker) for human review. Use this skill
+  whenever the user mentions SageMaker migration, converting SageMaker
+  Pipelines, porting workflow code from SageMaker, replacing SageMaker DSL
+  authoring with ZenML, or asks how a SageMaker Pipelines concept maps to
+  ZenML -- even if they do not explicitly say "migrate". Also use when they
+  paste `sagemaker.workflow.*` code and ask to make it work with ZenML, or
+  when they describe a workflow using SageMaker terms (`ProcessingStep`,
+  `TrainingStep`, `ConditionStep`, `PropertyFile`, `JsonGet`, `ModelStep`,
+  `PipelineSession`) in a ZenML context. If the user just asks a quick
+  conceptual question ("what's the ZenML equivalent of PropertyFile?"), answer
+  it directly from the concept map -- no need to run the full migration
+  workflow.
+---
+
+# Migrate SageMaker Pipelines to ZenML
+
+This skill translates Amazon SageMaker Pipelines and related workflow code into idiomatic ZenML pipelines. It handles the full migration workflow: analyzing the SageMaker pipeline, classifying each construct, translating what maps cleanly, flagging what needs redesign, and producing a working ZenML project.
+
+## How migration works at a high level
+
+SageMaker Pipelines and ZenML can run on the same AWS substrate, but they ask you to think about pipelines differently. Native SageMaker Pipelines is a **step-type DSL**: you choose `ProcessingStep`, `TrainingStep`, `TuningStep`, `TransformStep`, `ConditionStep`, and other managed-service wrappers, then wire them with pipeline parameters, step `.properties`, `PropertyFile`, and `JsonGet`.
+
+ZenML is **Python-step-first**: you write `@step` functions that consume and produce typed artifacts, and the active stack decides where they run. When you use ZenML's SageMaker orchestrator, you are usually **not leaving SageMaker**. You are keeping SageMaker as the execution backend while changing the authoring model to ZenML pipelines and stack settings.
+
+That means migration is not a rename-the-primitives exercise. Some patterns translate directly, some are approximate, and some require deliberate redesign.
+
+### The three mapping types
+
+Every SageMaker concept falls into one of these categories:
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Conceptual equivalent exists but semantics differ | Translate with caveats noted in migration report |
+| **Absent** | No ZenML equivalent | Flag for human review with redesign suggestions |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and Analyze the SageMaker Workflow
+
+Ask the user for their SageMaker pipeline code and any helper modules used by the pipeline. Useful inputs include:
+
+- The main pipeline Python file (`Pipeline(...)`, `pipeline.upsert()`, `pipeline.start()`)
+- Helper code used by processors, estimators, or model-registration logic
+- Evaluation code that emits JSON reports or uses `PropertyFile` / `JsonGet`
+- Scheduling snippets (`PipelineSchedule`, `put_triggers`, EventBridge role setup)
+- Any deployment, registry, Clarify, QualityCheck, Feature Store, or callback code
+
+Read everything thoroughly before doing anything else. For each pipeline, identify:
+
+1. **Step inventory** -- Which step types are used? (`ProcessingStep`, `TrainingStep`, `TransformStep`, `TuningStep`, `ConditionStep`, `FailStep`, `ModelStep`, `CreateModelStep`, `RegisterModel`, `CallbackStep`, `LambdaStep`, `QualityCheckStep`, `ClarifyCheckStep`, `EMRStep`, `NotebookJobStep`, `AutoMLStep`)
+2. **Data flow** -- Where are `Parameter*`, step `.properties`, `PropertyFile`, `JsonGet`, `ExecutionVariables`, or raw S3 URI handoffs used?
+3. **Control flow** -- Are there `ConditionStep` branches, multiple condition types, or failure gates?
+4. **Runtime and infrastructure** -- Are instance types, IAM roles, warm pools, S3 channels, tags, retries, or schedule roles embedded in pipeline code?
+5. **AWS service coupling** -- Does the pipeline depend on SageMaker Model Registry, Experiments, Feature Store, Clarify, Model Monitor, Lambda, SQS callbacks, EMR, or Notebook Jobs?
+6. **Migration target choice** -- Is the best path "portable ZenML first", or "keep SageMaker explicitly" using the SageMaker orchestrator and/or AWS SDK calls inside steps?
+
+### Phase 2: Classify and Plan
+
+For each component identified in Phase 1, classify it using the mapping type (direct / approximate / absent). Use the decision logic below and the full tables in [references/concept-map.md](references/concept-map.md).
+
+#### Quick classification guide
+
+**Direct translations (translate automatically):**
+- `Pipeline` -> `@pipeline`
+- `ParameterString` / `ParameterInteger` / `ParameterFloat` / `ParameterBoolean` -> typed pipeline parameters
+- `ProcessingStep` -> `@step`
+- `TrainingStep` -> `@step`
+- `FailStep` -> raise an exception in a step
+
+**Approximate translations (translate with caveats):**
+- `ConditionStep` -> Python control flow, often `@pipeline(dynamic=True)` plus `.load()` for small control artifacts (note that dynamic pipelines are still experimental, and SageMaker-orchestrator scheduling does not support them)
+- `PropertyFile` / `JsonGet` intent -> typed artifacts and normal Python access
+- S3 input/output channels -> `SagemakerOrchestratorSettings`
+- cache / retry behavior -> ZenML caching plus `StepRetryConfig`, while noting that SageMaker service-specific retry semantics may differ
+- `TuningStep`, `TransformStep`, `QualityCheckStep`, `ClarifyCheckStep`, `EMRStep`, `NotebookJobStep`, `AutoMLStep` -> ZenML `@step` that explicitly launches the corresponding AWS-native behavior
+- `ModelStep`, `CreateModelStep`, `RegisterModel` -> explicit SageMaker model / registry calls in steps, or an intentional redesign to ZenML Model Control Plane
+- SageMaker Experiments -> experiment tracker component and/or explicit SageMaker experiment calls
+
+**Absent / needs redesign (flag for human review):**
+- Exact step `.properties` placeholder semantics
+- Exact `PropertyFile` / `JsonGet` backend-evaluation behavior
+- Native `CallbackStep` token-handshake semantics
+- Native `LambdaStep` semantics when the original design relies on its I/O and timeout constraints
+- Dynamic pipeline scheduling on the SageMaker orchestrator
+- Any claim that SageMaker Model Registry == ZenML MCP
+- Any claim that SageMaker Feature Store is usefully covered today by the ZenML feature-store abstraction
+
+#### Present the migration plan
+
+Before writing any code, present a summary to the user:
+
+> "Here's what I found in your SageMaker pipeline:
+> - **Direct translations** (will migrate cleanly): [list]
+> - **Approximate translations** (will work but with noted caveats): [list]
+> - **Needs redesign** (cannot auto-migrate safely): [list with brief explanation]
+>
+> Shall I proceed with the migration?"
+
+If there are HIGH-severity flags, explain each one concretely: what the SageMaker code does, why ZenML cannot replicate it directly, and what the recommended redesign looks like.
+
+### Phase 3: Generate ZenML Code
+
+Translate the SageMaker workflow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── preprocess.py
+│   ├── train.py
+│   └── evaluate.py
+├── pipelines/
+│   └── my_pipeline.py        # Pipeline definition
+├── materializers/            # Custom materializers (if needed)
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+This matches the `zenml-pipeline-authoring` skill's conventions. Key rules:
+- One step per file in `steps/`
+- Separate pipeline definition from execution
+- `run.py` uses `argparse` (click conflicts with ZenML)
+- `pyproject.toml` with `zenml>=0.94.1` and `requires-python = ">=3.12"`
+- Always generate `configs/dev.yaml` AND `configs/prod.yaml`
+- Always generate a `README.md` explaining the migrated pipeline and what still needs human review
+- Include a brief ASCII DAG diagram in the pipeline file's module docstring
+- Run `zenml init` at project root
+
+#### Translation patterns
+
+For each SageMaker construct, apply the appropriate translation. See [references/code-patterns.md](references/code-patterns.md) for detailed side-by-side examples covering the major migration patterns.
+
+**The core translation rule**: move the pipeline's real business logic into `@step` functions with typed inputs and outputs. Use artifacts for data flow. Use `SagemakerOrchestratorSettings` only for runtime concerns you intentionally want to preserve on SageMaker.
+
+```python
+# SageMaker: step-type DSL + placeholder-driven wiring
+# ZenML: explicit Python step interface + artifact wiring
+
+@step
+def evaluate(model_uri: str) -> dict[str, float]:
+    return {"accuracy": 0.93}
+
+@pipeline
+def training_pipeline(model_uri: str) -> None:
+    metrics = evaluate(model_uri)
+    register_model(metrics=metrics)
+```
+
+**`PropertyFile` / `JsonGet` -> Artifact passing**: replace JSONPath-style placeholder extraction with structured return values:
+
+```python
+@step
+def evaluate_model() -> dict[str, float]:
+    return {"accuracy": 0.93, "f1": 0.91}
+
+@pipeline(dynamic=True)
+def gated_pipeline() -> None:
+    metrics = evaluate_model()
+    if metrics.load()["accuracy"] >= 0.9:
+        deploy_model(metrics=metrics)
+```
+
+Use `.load()` only for **small control artifacts**. For large datasets or models, keep the value as an artifact edge and make decisions on a summarized artifact instead.
+
+**Keep-SageMaker runtime mapping**: when preserving SageMaker runtime behavior, move instance types, S3 channels, warm pools, tags, and similar infrastructure knobs into `SagemakerOrchestratorSettings`, not business-logic parameters.
+
+#### Dependency guidance
+
+Do not force every migrated project to depend on the full SageMaker SDK.
+
+- Always include the baseline ZenML requirements
+- Add `boto3` and/or `sagemaker` only if the migrated project still makes AWS-native service calls or uses SageMaker-specific settings imports
+- If the migration becomes fully portable ZenML, keep the dependency set small
+
+#### Code comment style
+
+Keep migration-related comments concise and actionable. Use `# Migration note:` for brief inline caveats and `# TODO(migration):` for items requiring user action. Put the long explanation in `MIGRATION_REPORT.md`, not in code comments.
+
+#### Handling approximate translations
+
+When translating approximate patterns, add a short comment explaining what changed:
+
+```python
+@step
+def register_in_sagemaker(model_package_group: str, model_data_uri: str) -> str:
+    # Migration note: the original pipeline used SageMaker ModelStep/RegisterModel.
+    # This ZenML step keeps AWS-native registration explicitly instead of pretending
+    # ZenML MCP is a 1:1 replacement for SageMaker Model Registry.
+    ...
+```
+
+#### Handling absent patterns
+
+For patterns that have no ZenML equivalent, do NOT silently approximate them. Instead:
+
+1. Add a clearly marked `# TODO(migration)` comment in the generated code
+2. Include the pattern in the migration report
+3. Suggest a redesign approach
+
+```python
+# TODO(migration): UNSUPPORTED -- the original pipeline used CallbackStep token
+# handshake semantics. ZenML has no equivalent native callback step. Keep this
+# portion as an explicit AWS workflow (for example Step Functions or an AWS API
+# step) or redesign the orchestration boundary.
+@step
+def request_external_review() -> None:
+    ...
+```
+
+### Phase 4: Produce the Migration Report
+
+After generating the ZenML project, produce a `MIGRATION_REPORT.md` in the project root:
+
+```markdown
+# Migration Report: [SageMaker Pipeline Name] -> [ZenML Pipeline Name]
+
+## Summary
+- **Source**: SageMaker pipeline `[pipeline_name]`
+- **Target**: ZenML pipeline `[target_pipeline_name]`
+- **Steps migrated**: X direct, Y approximate, Z flagged
+
+## Direct Translations
+| SageMaker Construct | ZenML Equivalent | Notes |
+|---|---|---|
+| ProcessingStep `Preprocess` | `steps/preprocess.py` | Clean translation to `@step` |
+
+## Approximate Translations
+| SageMaker Construct | ZenML Equivalent | What Changed |
+|---|---|---|
+| ConditionStep `Gate` | dynamic pipeline branch | Backend placeholder evaluation became Python control flow |
+| RegisterModel | explicit registration step | Kept SageMaker registry call explicit |
+
+## Flagged for Review
+| SageMaker Pattern | Severity | Issue | Suggested Redesign |
+|---|---|---|---|
+| CallbackStep | HIGH | No native callback-token step in ZenML | Keep as explicit AWS workflow or redesign boundary |
+
+## SageMaker Runtime Mapping
+| Native SageMaker concern | ZenML equivalent | Notes |
+|---|---|---|
+| Instance type / volume | `SagemakerOrchestratorSettings` | Runtime concern, not business logic |
+| S3 channels | `SagemakerOrchestratorSettings` | Preserve only when exact AWS semantics matter |
+| Model Registry | explicit SageMaker step or ZenML MCP | Choose intentionally |
+
+## Scheduling
+- **Original**: [native schedule / trigger details]
+- **Migrated**: [ZenML `Schedule(...)` or manual trigger design]
+- **Note**: SageMaker orchestrator supports cron / interval / one-time schedules, but dynamic pipelines cannot be scheduled there
+
+## Limitations and Key Differences
+[Put the most important semantic differences here before the benefits section.]
+
+## What's NOT Migrated
+[List SageMaker-native service behavior that was intentionally left AWS-specific or requires manual review.]
+
+## What You Get for Free After Migration
+- **Artifact lineage and versioning**
+- **Step caching**
+- **Stack abstraction**
+- **Experiment tracker integrations**
+- **Model Control Plane**
+- **Service connectors**
+
+## Recommended Next Steps
+1. Run the `zenml-quick-wins` skill
+2. Install the ZenML docs MCP server
+3. Review the flagged items with the linked docs
+4. Use `zenml-pipeline-authoring` for deeper customization
+```
+
+### Phase 5: Suggest Next Steps
+
+After migration is complete, always include a "Recommended Next Steps" section in the migration report AND communicate it to the user.
+
+#### 1. Run the `zenml-quick-wins` skill
+
+Always suggest this as the immediate next step:
+
+> "Now that the migration is done, I'd recommend running the `zenml-quick-wins` skill to add metadata logging, experiment tracking, alerters, and other production features to your pipeline."
+
+#### 2. Documentation links for flagged patterns
+
+For every flagged pattern, include links to the relevant ZenML docs:
+
+- SageMaker orchestrator: `https://docs.zenml.io/stacks/stack-components/orchestrators/sagemaker`
+- Scheduling: `https://docs.zenml.io/concepts/steps_and_pipelines/scheduling`
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- Service connectors / auth: `https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/aws-service-connector`
+- Artifact and stack concepts: `https://docs.zenml.io/stacks`
+- Models / MCP: `https://docs.zenml.io/how-to/model-management-metrics/model-control-plane/register-a-model`
+
+When the migrated project intentionally preserves AWS-native service calls, include AWS documentation links for those preserved service-specific patterns too.
+
+#### 3. Suggest installing the ZenML docs MCP server
+
+> "For easier access to ZenML documentation while you work, you can install the ZenML docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Community support for unsupported patterns
+
+When the migration has HIGH-severity flags -- patterns that could not be directly migrated -- offer to help the user get support from the ZenML community. **When there are 2+ HIGH-severity flags**, generate a pre-made Slack message for `zenml.io/slack` summarizing the SageMaker pipeline, the unsupported patterns, the attempted workarounds, and the concrete question for the ZenML team.
+
+#### 5. Open GitHub issues for genuine feature gaps
+
+When the migration reveals a genuine missing feature in ZenML, offer to open a GitHub issue on `zenml-io/zenml` using `gh issue create`. Include the SageMaker pattern, the attempted workaround, and why the feature would help real migrations.
+
+#### 6. Run `/simplify` to clean up the migrated code
+
+After migration is complete, always suggest running `/simplify` on the generated code. Migration often leaves behind caveat comments, duplicated wrappers, and portability notes that should be tightened up before the code feels production-ready.
+
+#### 7. Further customization via `zenml-pipeline-authoring`
+
+The `zenml-pipeline-authoring` skill handles deeper customization:
+- Docker settings for remote execution
+- YAML configuration for multi-environment setups
+- Custom materializers for domain-specific types
+- Deployment and post-migration refinement
+
+## Important Behavioral Differences to Communicate
+
+These are the most common sources of confusion after migration. Always mention the relevant ones in the migration report.
+
+### Step-type DSL != uniform ZenML steps
+
+SageMaker pipeline code encodes AWS service choices directly in the graph: `ProcessingStep`, `TrainingStep`, `TransformStep`, `TuningStep`, and so on. ZenML uses a uniform `@step` abstraction, so service-specific behavior often moves **inside** the step body as an explicit SDK call or into orchestrator settings.
+
+### Placeholder expressions != artifacts
+
+SageMaker uses backend-evaluated placeholders such as step `.properties`, `PropertyFile`, and `JsonGet`. ZenML uses typed artifacts and normal Python values. This changes:
+- Where values are evaluated
+- How data is serialized
+- What gets cached
+- How downstream control flow is expressed
+
+### Scheduling lifecycle differs
+
+ZenML can schedule SageMaker-orchestrated pipelines, but schedule lifecycle management is not the same as native SageMaker. Dynamic pipelines are supported on the SageMaker orchestrator in general, but they cannot currently be scheduled there. Re-running a scheduled pipeline creates a new SageMaker pipeline / schedule rather than updating the old one.
+
+### Model governance semantics differ
+
+SageMaker Model Registry and SageMaker Experiments are not 1:1 with ZenML MCP and experiment trackers. For SageMaker Feature Store specifically, do **not** present the ZenML feature-store abstraction as a practical out-of-the-box replacement. If the user needs first-class SageMaker Feature Store support, keep the AWS-native usage explicit and suggest discussing the need in `zenml.io/slack` or contributing an integration.
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Keeping `PropertyFile` / `JsonGet` just to mimic the old DSL | Recreates placeholder complexity and loses most ZenML benefits | Return typed artifacts and index them normally |
+| Mapping infrastructure parameters to ordinary business-logic args | Blurs runtime config with pipeline semantics | Move instance types, S3 channels, tags, warm pools into orchestrator settings |
+| Pretending SageMaker Model Registry == ZenML MCP | They overlap in intent, not in semantics | Choose a registry strategy explicitly |
+| Pretending SageMaker Feature Store is covered by the ZenML feature-store abstraction | That overstates current support and sets the user up for the wrong migration plan | Keep SageMaker Feature Store explicit, or discuss a custom/community integration path |
+| Translating `ConditionStep` without noting control-flow changes | Backend placeholder evaluation and Python branching behave differently | Flag the change and use dynamic pipelines carefully |
+| Silently collapsing `TuningStep` into one training step | Destroys original HPO behavior | Keep an explicit HPO step design |
+| Claiming Lambda / callback primitives are preserved | They are not native ZenML concepts | Keep them as explicit AWS integrations or redesign |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) -- Full concept mapping tables, scheduling caveats, and stack-component mappings
+- [references/code-patterns.md](references/code-patterns.md) -- Side-by-side code translations for core SageMaker patterns
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) -- Must-flag patterns, behavioral differences, migration decision tree, and anti-patterns
+
+### ZenML documentation
+
+For topics beyond migration (stack setup, deployment, experiment tracking, model management), query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/code-patterns.md
+++ b/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/code-patterns.md
@@ -1,0 +1,349 @@
+# SageMaker Pipelines → ZenML Code Patterns
+
+These examples show the most common SageMaker-to-ZenML translations. They are not meant to be copied blindly. Use them as patterns, then adjust imports, dependencies, and settings to match the user's actual pipeline.
+
+## 1. Simple `ProcessingStep` + `TrainingStep` -> `@step` + `@pipeline`
+
+### SageMaker SDK
+
+```python
+from sagemaker.processing import ScriptProcessor
+from sagemaker.sklearn.estimator import SKLearn
+from sagemaker.workflow.pipeline import Pipeline
+from sagemaker.workflow.pipeline_context import PipelineSession
+from sagemaker.workflow.steps import ProcessingStep, TrainingStep
+
+pipeline_session = PipelineSession()
+
+processor = ScriptProcessor(..., sagemaker_session=pipeline_session)
+estimator = SKLearn(..., sagemaker_session=pipeline_session)
+
+step_process = ProcessingStep(
+    name="Preprocess",
+    step_args=processor.run(code="preprocess.py"),
+)
+
+step_train = TrainingStep(
+    name="Train",
+    step_args=estimator.fit(inputs={"train": step_process.properties.ProcessingOutputConfig.Outputs["train"].S3Output.S3Uri}),
+)
+
+pipeline = Pipeline(name="train-pipeline", steps=[step_process, step_train])
+```
+
+### ZenML
+
+```python
+from typing import Tuple
+
+from zenml import pipeline, step
+
+@step
+def preprocess() -> Tuple[str, str]:
+    train_uri = "s3://bucket/processed/train"
+    validation_uri = "s3://bucket/processed/validation"
+    return train_uri, validation_uri
+
+@step
+def train(train_uri: str, validation_uri: str) -> str:
+    return "s3://bucket/model/model.tar.gz"
+
+@pipeline
+def training_pipeline() -> None:
+    train_uri, validation_uri = preprocess()
+    train(train_uri=train_uri, validation_uri=validation_uri)
+```
+
+**Migration note:** the graph now expresses data flow through typed step outputs, not through step-property placeholders.
+
+## 2. Pipeline parameters -> typed Python parameters
+
+### SageMaker SDK
+
+```python
+from sagemaker.workflow.parameters import ParameterFloat, ParameterString
+
+input_data = ParameterString(name="InputData", default_value="s3://bucket/raw.csv")
+threshold = ParameterFloat(name="Threshold", default_value=0.9)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def evaluate(input_data_uri: str, threshold: float) -> bool:
+    return threshold >= 0.9
+
+@pipeline
+def pipeline_with_params(input_data_uri: str = "s3://bucket/raw.csv", threshold: float = 0.9) -> None:
+    evaluate(input_data_uri=input_data_uri, threshold=threshold)
+```
+
+**Migration warning:** if the original SageMaker parameter controlled infrastructure such as `instance_type` or `instance_count`, do **not** map it to an ordinary business-logic parameter. Move that concern into orchestrator settings instead.
+
+## 3. `PropertyFile` + `JsonGet` -> artifacts and normal Python access
+
+### SageMaker SDK
+
+```python
+from sagemaker.workflow.functions import JsonGet
+from sagemaker.workflow.properties import PropertyFile
+from sagemaker.workflow.steps import ProcessingStep
+
+evaluation_report = PropertyFile(
+    name="EvaluationReport",
+    output_name="evaluation",
+    path="evaluation.json",
+)
+
+step_eval = ProcessingStep(
+    name="Evaluate",
+    property_files=[evaluation_report],
+    step_args=processor.run(code="evaluate.py"),
+)
+
+accuracy = JsonGet(
+    step_name=step_eval.name,
+    property_file=evaluation_report,
+    json_path="metrics.accuracy",
+)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def evaluate() -> dict[str, float]:
+    return {"accuracy": 0.93, "f1": 0.91}
+
+@pipeline(dynamic=True)
+def gated_pipeline() -> None:
+    metrics = evaluate()
+    if metrics.load()["accuracy"] >= 0.9:
+        promote_model(metrics=metrics)
+```
+
+**Migration warning:** this is a real semantic rewrite. Do not keep writing JSON files just to emulate `PropertyFile` unless you are preserving an external contract.
+
+## 4. `ConditionStep` -> dynamic pipeline control flow
+
+### SageMaker SDK
+
+```python
+from sagemaker.workflow.condition_step import ConditionStep
+from sagemaker.workflow.conditions import ConditionGreaterThan
+from sagemaker.workflow.functions import JsonGet
+
+gate = ConditionStep(
+    name="AccuracyGate",
+    conditions=[
+        ConditionGreaterThan(
+            left=JsonGet(step_name=step_eval.name, property_file=evaluation_report, json_path="metrics.accuracy"),
+            right=0.9,
+        )
+    ],
+    if_steps=[step_register],
+    else_steps=[step_fail],
+)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline, step
+
+@step
+def evaluate_model() -> dict[str, float]:
+    return {"accuracy": 0.93}
+
+@step
+def fail_pipeline(message: str) -> None:
+    raise RuntimeError(message)
+
+@pipeline(dynamic=True)
+def training_pipeline() -> None:
+    metrics = evaluate_model()
+    if metrics.load()["accuracy"] >= 0.9:
+        register_model(metrics=metrics)
+    else:
+        fail_pipeline(message="Accuracy below deployment threshold")
+```
+
+**Migration note:** SageMaker evaluates conditions on backend placeholders. ZenML evaluates regular Python logic. Use `.load()` only for small control artifacts.
+
+## 5. S3 channels and runtime settings -> `SagemakerOrchestratorSettings`
+
+### SageMaker SDK
+
+```python
+processor.run(
+    code="preprocess.py",
+    inputs=[ProcessingInput(source="s3://bucket/raw", destination="/opt/ml/processing/input")],
+    outputs=[ProcessingOutput(source="/opt/ml/processing/output", destination="s3://bucket/output")],
+)
+```
+
+### ZenML
+
+```python
+from zenml import step
+from zenml.integrations.aws.flavors.sagemaker_orchestrator_flavor import (
+    SagemakerOrchestratorSettings,
+)
+
+channel_settings = SagemakerOrchestratorSettings(
+    instance_type="ml.m5.large",
+    input_data_s3_mode="File",
+    input_data_s3_uri={"raw": "s3://bucket/raw"},
+    output_data_s3_mode="EndOfJob",
+    output_data_s3_uri="s3://bucket/output",
+    keep_alive_period_in_seconds=300,
+)
+
+@step(settings={"orchestrator": channel_settings})
+def preprocess_from_channels() -> None:
+    ...
+```
+
+**Migration warning:** preserving SageMaker channels is useful when exact SageMaker job semantics matter, but it is less portable than artifact-first ZenML.
+
+## 6. `TuningStep` -> explicit HPO step
+
+### SageMaker SDK
+
+```python
+from sagemaker.tuner import HyperparameterTuner
+from sagemaker.workflow.steps import TuningStep
+
+tuner = HyperparameterTuner(estimator=estimator, objective_metric_name="validation:rmse", ...)
+step_tune = TuningStep(name="TuneModel", step_args=tuner.fit(inputs={"train": train_uri}))
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+@step
+def tune_model(train_uri: str) -> dict[str, str]:
+    # Migration note: this keeps SageMaker HPO explicitly instead of pretending
+    # the original TuningStep is equivalent to a normal training step.
+    return {"best_model_uri": "s3://bucket/best-model.tar.gz"}
+```
+
+**Migration warning:** never silently translate `TuningStep` into a single `@step` that trains once.
+
+## 7. `TransformStep` -> explicit Batch Transform step
+
+### SageMaker SDK
+
+```python
+from sagemaker.transformer import Transformer
+from sagemaker.workflow.steps import TransformStep
+
+transformer = Transformer(model_name="my-model", instance_type="ml.m5.large", instance_count=1)
+step_transform = TransformStep(
+    name="BatchTransform",
+    transformer=transformer,
+    inputs=TransformInput(data="s3://bucket/batch-input"),
+)
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+@step
+def run_batch_transform(model_name: str, input_s3_uri: str) -> str:
+    # Migration note: ZenML has no first-class batch transform step.
+    # Keep the AWS-native behavior explicit if you need it.
+    return "s3://bucket/batch-output"
+```
+
+## 8. `ModelStep` / `RegisterModel` -> explicit registry choice
+
+### SageMaker SDK
+
+```python
+step_model_registration = ModelStep(
+    name="RegisterModel",
+    step_args=model.register(
+        content_types=["*"],
+        response_types=["application/json"],
+        inference_instances=["ml.m5.xlarge"],
+        transform_instances=["ml.m5.xlarge"],
+    ),
+)
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+@step
+def register_model_explicitly(model_data_uri: str, model_package_group: str) -> str:
+    # Migration note: choose intentionally between:
+    # 1. explicit SageMaker registration, or
+    # 2. redesigning model governance around ZenML MCP.
+    return "arn:aws:sagemaker:eu-west-1:123456789012:model-package/my-model"
+```
+
+**Migration warning:** "SageMaker Model Registry == ZenML MCP" is false. They overlap in intent, not semantics.
+
+## 9. Scheduling -> `Schedule(...)` with SageMaker caveats
+
+### SageMaker SDK
+
+```python
+from sagemaker.workflow.triggers import PipelineSchedule
+
+pipeline.put_triggers(
+    triggers=[PipelineSchedule(cron="0 3 * * ? *", name="daily-training")],
+    role_arn="<SCHEDULER_ROLE_ARN>",
+)
+```
+
+### ZenML
+
+```python
+from zenml import pipeline
+from zenml.config.schedule import Schedule
+
+@pipeline
+def scheduled_pipeline() -> None:
+    ...
+
+scheduled_pipeline.with_options(
+    schedule=Schedule(cron_expression="0 3 * * *")
+)()
+```
+
+**Migration warning:** the SageMaker orchestrator supports cron / interval / one-time scheduling, but dynamic pipelines cannot currently be scheduled there, and ZenML does not natively manage schedule updates/deletes on SageMaker.
+
+## 10. `CallbackStep` / `LambdaStep` -> explicit redesign
+
+### SageMaker SDK
+
+```python
+step_callback = CallbackStep(...)
+step_lambda = LambdaStep(...)
+```
+
+### ZenML
+
+```python
+from zenml import step
+
+@step
+def invoke_lambda_explicitly(payload: dict[str, str]) -> dict[str, str]:
+    # TODO(migration): preserve AWS-native Lambda semantics explicitly.
+    return {"status": "submitted"}
+```
+
+**Migration warning:** do not pretend these are normal ZenML primitives. Keep the AWS integration explicit or redesign the orchestration boundary.

--- a/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/concept-map.md
+++ b/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/concept-map.md
@@ -1,0 +1,113 @@
+# SageMaker Pipelines → ZenML Concept Map
+
+Complete mapping of SageMaker Pipelines concepts to their ZenML equivalents. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (conceptual equivalent with different semantics), or **absent** (no ZenML equivalent — needs redesign).
+
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [Step Types](#step-types)
+- [Data Passing and Parameters](#data-passing-and-parameters)
+- [Control Flow and Scheduling](#control-flow-and-scheduling)
+- [Infrastructure and AWS Integrations](#infrastructure-and-aws-integrations)
+- [Model Management and Stack Components](#model-management-and-stack-components)
+
+## Core Concepts
+
+| SageMaker Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Pipeline` | `@pipeline` | direct | Both define a workflow graph. ZenML authoring is Python-first rather than a SageMaker workflow DSL. |
+| `PipelineSession` | No direct equivalent | absent | SageMaker uses it to capture `.fit()` / `.run()` calls into a pipeline definition. ZenML authoring does not require this layer. |
+| `PipelineDefinitionConfig` | No direct equivalent | absent | ZenML does not expose a user-facing pipeline-definition compilation API. |
+| `pipeline.upsert()` | Pipeline invocation on a configured stack | approximate | Similar intent, different lifecycle. ZenML manages deployment through the orchestrator. |
+| `pipeline.start(parameters=...)` | Calling the pipeline with args or `.with_options(...)()` | approximate | Same high-level goal, different API surface. |
+| `execution.wait()` | Normal client-side run waiting / tracking | approximate | ZenML run handling is not modeled as the same SageMaker execution object. |
+| `PipelineExperimentConfig` | Experiment tracker component and/or explicit SageMaker experiment calls | approximate | Similar intent, different object model. |
+| `ParallelismConfiguration` | Orchestrator/runtime-dependent parallelism | approximate | No single top-level ZenML equivalent with the same semantics. |
+| `SelectiveExecutionConfig` | Caching plus explicit reruns / pipeline edits | approximate | Similar user intent, different implementation model. |
+
+## Step Types
+
+| SageMaker Step Type | ZenML Mapping | Mapping | Must Flag? | Notes |
+|---|---|:---:|:---:|---|
+| `ProcessingStep` | `@step` | direct | No | Usually the easiest migration. |
+| `TrainingStep` | `@step` | direct | No | Keep the training logic in Python; decide separately whether to preserve SageMaker runtime settings. |
+| `FailStep` | Step that raises an exception | approximate | No | Preserves intent, but no dedicated failure node exists in the ZenML graph. |
+| `ConditionStep` | Python control flow, often `@pipeline(dynamic=True)` | approximate | Yes | Backend placeholder evaluation becomes Python logic. Dynamic pipelines are still experimental. |
+| `TuningStep` | `@step` that launches HPO explicitly | approximate | Yes | Do not collapse to a single training run. |
+| `TransformStep` | `@step` that launches Batch Transform explicitly | approximate | Yes | No native ZenML batch-transform primitive. |
+| `ModelStep` | `@step` that performs explicit SageMaker model / registry work | approximate | Yes | Modern SageMaker path for create/register flows. |
+| `CreateModelStep` | `@step` that calls SageMaker model APIs | approximate | Yes | Older API still appears in source pipelines. |
+| `RegisterModel` | `@step` that calls SageMaker Model Registry APIs | approximate | Yes | Not the same as ZenML MCP. |
+| `CallbackStep` | Explicit AWS integration step or redesign | absent | Yes | No native callback-token step in ZenML. |
+| `LambdaStep` | Explicit boto3 Lambda call or redesign | absent | Yes | No native Lambda step; I/O and timeout semantics differ. |
+| `QualityCheckStep` | `@step` that runs explicit quality-check logic | approximate | Yes | SageMaker baseline lifecycle is not preserved automatically. |
+| `ClarifyCheckStep` | `@step` that runs Clarify or custom checks | approximate | Yes | Same caution as quality checks. |
+| `EMRStep` | `@step` that submits EMR work | approximate | Yes | ZenML has no EMR step type. |
+| `NotebookJobStep` | Rewrite notebook as code, or explicit notebook-job call | approximate | Yes | ZenML prefers Python steps over notebook-job orchestration. |
+| `AutoMLStep` | `@step` that launches Autopilot / AutoML APIs | approximate | Yes | No native ZenML AutoML step primitive. |
+
+## Data Passing and Parameters
+
+| SageMaker Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `ParameterString` / `ParameterInteger` / `ParameterFloat` / `ParameterBoolean` | Typed pipeline parameters | direct | Usually a clean migration to Python arguments. |
+| `ExecutionVariables` | Python values, step context, or logged metadata | approximate | No equivalent placeholder-expression system. |
+| `Join` | Normal Python string formatting | approximate | Prefer explicit Python values over placeholder syntax. |
+| `ProcessingInput` / `TrainingInput` | Artifact input or S3 channel settings | approximate | Use artifacts for idiomatic ZenML; keep S3 channels only when AWS-native semantics matter. |
+| `ProcessingOutput` | Artifact output or S3 export settings | approximate | Same portability trade-off as inputs. |
+| `TransformInput` | Explicit Batch Transform API args | approximate | No direct ZenML primitive. |
+| Step `.properties` | Artifact values or metadata | absent | Placeholder property-path access is replaced, not preserved. |
+| `PropertyFile` | Typed artifact returned from a step | absent | This is a data-model rewrite, not a shim. |
+| `JsonGet` | Normal Python indexing on a loaded artifact | absent | Typically `metrics.load()[\"accuracy\"]` or a named field on a dataclass. |
+| Large S3 URIs passed between steps | Artifact store or explicit URI artifacts | approximate | Keep raw URIs only when downstream AWS-native APIs genuinely require them. |
+
+## Control Flow and Scheduling
+
+| SageMaker Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `ConditionStep` | `@pipeline(dynamic=True)` + Python `if` / `else` | approximate | Use `.load()` only for small control artifacts. |
+| `ConditionEquals` / `ConditionGreaterThan` / `ConditionLessThan` / related condition types | Python boolean expressions | approximate | Same logical intent, different execution environment. |
+| `ConditionOr` / `ConditionNot` | `or` / `not` | approximate | Same caution: Python runtime instead of backend placeholder evaluation. |
+| `depends_on` | Natural dependencies from artifact wiring or explicit control code | approximate | ZenML derives dependencies from data flow more often than from explicit graph declarations. |
+| `PipelineSchedule` / `put_triggers()` | `Schedule(...)` + `.with_options(schedule=...)()` | approximate | Similar goal, different API surface. |
+| Update schedule in place | No native SageMaker schedule management in ZenML | absent | Re-running a scheduled SageMaker pipeline creates a new schedule rather than updating the old one. |
+| Dynamic pipeline scheduling on SageMaker orchestrator | Not supported | absent | Important migration caveat for `ConditionStep`-style pipelines. |
+
+### Scheduling on the SageMaker Orchestrator
+
+| Orchestrator | Scheduling Support | Supported Types | Native Schedule Management |
+|---|:---:|---|:---:|
+| `SagemakerOrchestrator` | Yes | Cron, Interval, One-time | No |
+
+**Important caveat:** dynamic pipelines cannot currently be scheduled on the SageMaker orchestrator. If the migrated pipeline needs runtime branching **and** native SageMaker-backed scheduling, flag this immediately.
+
+## Infrastructure and AWS Integrations
+
+| SageMaker / AWS Concern | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| Execution role | Orchestrator `execution_role` | direct | Core runtime mapping when keeping SageMaker. |
+| Scheduler role | Orchestrator `scheduler_role` | direct | Needed for scheduled SageMaker-backed runs. |
+| Client AWS auth | Service connector, explicit credentials, or implicit AWS profile | direct | Service connector is the recommended ZenML pattern. |
+| Instance type / volume / environment | `SagemakerOrchestratorSettings` | direct | These are runtime settings, not business-logic parameters. |
+| Warm pools | `keep_alive_period_in_seconds` | direct | Useful, but multichannel output or output modes other than `EndOfJob` make warm pools unavailable. |
+| Force Training-step path | `use_training_step=True/False` | direct | Preserve intentionally; do not scatter this across business logic. |
+| S3 import channels | `input_data_s3_uri`, `input_data_s3_mode` | direct | Good for "keep SageMaker" migrations. |
+| S3 export channels | `output_data_s3_uri`, `output_data_s3_mode` | direct | Multichannel output or output modes other than `EndOfJob` prevent using TrainingStep and warm pools. |
+| Pipeline tags / job tags | `pipeline_tags`, `tags` | direct | Good keep-SageMaker runtime mapping. |
+| `CallbackStep` / SQS workflows | Explicit step code or external orchestration | absent | Requires a deliberate protocol design. |
+| `LambdaStep` | Explicit step code calling Lambda | absent | Preserve the AWS dependency explicitly if kept. |
+| SageMaker Experiments | Experiment tracker or explicit SageMaker experiment APIs | approximate | Similar goal, different semantics. |
+| SageMaker Feature Store | Keep explicit SageMaker Feature Store usage, or build a custom integration | absent | Do not present the ZenML feature-store abstraction as a practical SageMaker Feature Store replacement. |
+| Clarify / Model Monitor | Explicit SageMaker service calls inside steps | approximate | No first-class ZenML step type for these services. |
+
+## Model Management and Stack Components
+
+| SageMaker Concept | ZenML Equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `CreateModelStep` | Explicit SageMaker model step or redesign | approximate | Keep AWS-native semantics only when you need them. |
+| `RegisterModel` | Explicit SageMaker registry step or ZenML MCP | approximate | Choose the source of truth intentionally. |
+| `ModelStep` | Explicit SageMaker model / registry step | approximate | Preferred modern SageMaker SDK path for some workflows. |
+| Model Package Group | Explicit SageMaker registry calls | approximate | There is no 1:1 ZenML object. |
+| Approval statuses | ZenML model stages / approvals, or explicit SageMaker approvals | approximate | Similar governance intent, different lifecycle semantics. |
+| Hosted endpoint deployment | Explicit SageMaker endpoint APIs or a deliberate ZenML serving choice | approximate | Do not hide this design choice. |
+| ZenML Model Control Plane | No native SageMaker Pipelines equivalent | direct on ZenML side | This is additive capability, not a registry shim. |

--- a/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/gaps-and-flags.md
+++ b/skills/zenml-sagemaker-migration/skills/sagemaker-migration/references/gaps-and-flags.md
@@ -1,0 +1,228 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the patterns that are most dangerous to silently approximate during a SageMaker-to-ZenML migration -- the places where the two systems behave fundamentally differently, and where a naive translation changes the pipeline's actual behavior.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No SageMaker Equivalent](#zenml-features-with-no-sagemaker-equivalent)
+- [Anti-Patterns in Migration](#anti-patterns-in-migration)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated. Flag them in the migration report and require human review.
+
+### `PropertyFile` + `JsonGet` + step `.properties`
+
+**What SageMaker does:** it treats step outputs as backend-visible placeholder structures. Downstream nodes can read specific JSON fields or step properties without materializing the whole output as a normal Python object.
+
+**Why it matters:** this is one of the deepest semantic differences in the migration. SageMaker's placeholder system is part of the orchestration layer. ZenML uses artifacts and Python values instead.
+
+**ZenML gap:** there is no equivalent placeholder-expression system.
+
+**Redesign approach:** return typed artifacts from steps, then read those artifacts normally in downstream steps or in a dynamic pipeline for small control values.
+
+### `ConditionStep` over runtime placeholder values
+
+**What SageMaker does:** `ConditionStep` evaluates conditions on backend placeholder values and controls which downstream steps become ready.
+
+**Why it matters:** backend condition evaluation is not the same as Python control flow. Caching behavior, evaluation timing, and artifact materialization all change.
+
+**Redesign approach:**
+- If the branch depends only on pipeline parameters, use normal Python control flow in the pipeline definition.
+- If it depends on step outputs, use `@pipeline(dynamic=True)` and `.load()` only for small control artifacts.
+- If the pipeline also needs native SageMaker-backed scheduling, flag the design immediately because dynamic pipelines cannot currently be scheduled on the SageMaker orchestrator.
+
+### `TuningStep`
+
+**What SageMaker does:** it launches a managed hyperparameter-tuning job that can spawn many training jobs.
+
+**Why it matters:** collapsing that to one training step destroys the original behavior.
+
+**Redesign approach:** keep HPO explicit -- either launch SageMaker HPO from a ZenML step or deliberately redesign to another HPO system.
+
+### `TransformStep`
+
+**What SageMaker does:** it wraps SageMaker Batch Transform as a first-class pipeline step.
+
+**Why it matters:** ZenML has no first-class batch-transform step. A naive rewrite can silently remove AWS-managed inference semantics.
+
+**Redesign approach:** keep Batch Transform explicit inside a ZenML step, or intentionally redesign to ordinary offline inference code.
+
+### `ModelStep`, `CreateModelStep`, and `RegisterModel`
+
+**What SageMaker does:** it creates SageMaker model resources and/or registers model packages in SageMaker Model Registry.
+
+**Why it matters:** ZenML Model Control Plane is **not** a drop-in replacement for SageMaker Model Registry.
+
+**Redesign approach:** choose one of these deliberately:
+- keep SageMaker registration as explicit AWS-native step logic
+- redesign governance around ZenML MCP
+- do both, but make the dual-registration strategy explicit
+
+### `CallbackStep`
+
+**What SageMaker does:** it uses callback-token semantics and an external completion protocol.
+
+**Why it matters:** there is no native ZenML equivalent.
+
+**Redesign approach:** keep this portion as explicit AWS workflow logic, or move the orchestration boundary to another system such as Step Functions.
+
+### `LambdaStep`
+
+**What SageMaker does:** it invokes Lambda with Lambda-specific I/O and timeout semantics.
+
+**Why it matters:** a plain Python step is not the same thing.
+
+**Redesign approach:** invoke Lambda explicitly from a step if you truly need Lambda, and document the resulting AWS dependency.
+
+### SageMaker Feature Store parity claims
+
+**What SageMaker does:** it provides AWS-native feature-store workflows and APIs.
+
+**Why it matters:** do **not** tell the user that SageMaker Feature Store is meaningfully covered by the ZenML feature-store abstraction. That would overstate current support and send the migration in the wrong direction.
+
+**Redesign approach:** keep SageMaker Feature Store usage explicit inside AWS-native steps, or treat it as custom integration work. If the user wants first-class support, point them to `zenml.io/slack` to discuss it with the community/team, or suggest contributing the integration themselves.
+
+### Scheduling lifecycle on the SageMaker orchestrator
+
+**What SageMaker / ZenML do:** ZenML can create cron / interval / one-time schedules on the SageMaker orchestrator, but native schedule management is not supported there, and dynamic pipelines cannot currently be scheduled.
+
+**Why it matters:** users often assume "scheduled" also means "updateable in place" and "works for any pipeline shape." That is false here.
+
+**Redesign approach:** document the lifecycle clearly. If the original pipeline combined branching and native SageMaker scheduling, flag it and discuss alternatives.
+
+### Warm pools, training-step path, and output-mode constraints
+
+**What ZenML documents:** using multichannel output or output modes other than `EndOfJob` prevents using the training-step path and warm pools on the SageMaker orchestrator.
+
+**Why it matters:** this is the kind of runtime detail that silently changes startup behavior and cost if you ignore it.
+
+**Redesign approach:** surface the trade-off in the migration report and decide whether preserving output semantics or preserving warm-pool / training-step behavior matters more.
+
+---
+
+## Behavioral Differences
+
+### Step-type DSL vs uniform steps
+
+| Aspect | SageMaker Pipelines | ZenML |
+|---|---|---|
+| **Primary unit** | Step class (`ProcessingStep`, `TrainingStep`, `TransformStep`, etc.) | Python `@step` |
+| **Where service semantics live** | In the graph DSL | Often inside step code or orchestrator settings |
+| **How the graph is authored** | Workflow objects and placeholders | Python function composition |
+
+### Placeholders vs artifacts
+
+| Aspect | SageMaker | ZenML |
+|---|---|---|
+| **Data handoff** | Step properties, `PropertyFile`, `JsonGet`, parameters | Typed artifacts and Python values |
+| **Evaluation model** | Backend placeholder evaluation | Python evaluation and artifact materialization |
+| **Typical control-flow pattern** | Conditions over placeholder values | Dynamic pipelines with `.load()` for small control artifacts |
+| **Serialization model** | JSON files / service-specific outputs | Materializers and artifact store persistence |
+
+### Scheduling lifecycle
+
+| Aspect | Native SageMaker | ZenML on SageMaker |
+|---|---|---|
+| **Schedule types** | Cron, rate, at | Cron, interval, one-time |
+| **Schedule updates** | Managed via SageMaker APIs | Not natively managed by ZenML on SageMaker |
+| **Dynamic pipeline scheduling** | Not the same concern in native SageMaker DSL | Dynamic pipelines work on the SageMaker orchestrator, but scheduling them is not supported |
+
+### Model governance and experiments
+
+| Aspect | SageMaker | ZenML |
+|---|---|---|
+| **Model registry** | SageMaker Model Registry / model packages | ZenML MCP / models |
+| **Experiments** | SageMaker Experiments | Experiment trackers + ZenML runs |
+| **Feature store** | SageMaker Feature Store | No practical built-in SageMaker-equivalent wrapper; explicit AWS usage or custom integration |
+| **Main migration risk** | Assuming the names imply the same lifecycle semantics | They do not |
+
+---
+
+## Migration Decision Tree
+
+Text-based decision procedure for translating SageMaker patterns to ZenML:
+
+```text
+INPUT: construct_type, data_flow_pattern, scheduling_requirements, service_coupling
+
+IF construct_type IN {ProcessingStep, TrainingStep}:
+  EMIT normal @step
+  IF user wants to keep SageMaker runtime details:
+    MOVE instance/S3/tag/runtime knobs into SagemakerOrchestratorSettings
+
+ELSE IF construct_type == ConditionStep:
+  IF branch depends only on pipeline parameters:
+    EMIT normal Python conditional in the pipeline
+  ELSE:
+    EMIT @pipeline(dynamic=True)
+    USE .load() only for small control artifacts
+    IF scheduling_requirements include SageMaker-native scheduling:
+      FLAG blocker DYNAMIC_PIPELINE_SCHEDULING
+
+ELSE IF construct_type IN {PropertyFile, JsonGet, step.properties}:
+  REPLACE placeholder access with typed artifacts
+  FLAG warn DATA_MODEL_REWRITE
+
+ELSE IF construct_type == TuningStep:
+  EMIT explicit HPO step design
+  FLAG warn HPO_NOT_A_NORMAL_STEP
+
+ELSE IF construct_type == TransformStep:
+  EMIT explicit Batch Transform step
+  FLAG warn AWS_NATIVE_INFERENCE
+
+ELSE IF construct_type IN {ModelStep, CreateModelStep, RegisterModel}:
+  ASK which system should be the source of truth:
+    - SageMaker registry
+    - ZenML MCP
+    - both
+  EMIT explicit strategy
+
+ELSE IF construct_type IN {CallbackStep, LambdaStep}:
+  FLAG blocker EXPLICIT_AWS_WORKFLOW_REQUIRED
+  RECOMMEND keeping AWS-native logic explicit or redesigning the orchestration boundary
+
+ELSE IF construct_type IN {QualityCheckStep, ClarifyCheckStep, EMRStep, NotebookJobStep, AutoMLStep}:
+  EMIT explicit service-launching @step
+  FLAG warn SERVICE_SPECIFIC_SEMANTICS
+
+IF data_flow_pattern uses raw S3 URIs only to mimic placeholders:
+  PREFER artifacts instead
+ELSE IF AWS-native service calls require URIs:
+  KEEP URIs explicit and document the non-portable dependency
+```
+
+---
+
+## ZenML Features with No SageMaker Equivalent
+
+These are not migration problems. They are capabilities the user gets **after** migration:
+
+- **Artifact lineage and versioning** for every persisted output
+- **Step caching** based on code + inputs + parameters
+- **Stack abstraction** so the same pipeline can run on other backends later
+- **Service connectors** for managed cloud authentication
+- **Model Control Plane** as an additive governance layer
+
+Call these out in the "What You Get for Free After Migration" section of the migration report.
+
+---
+
+## Anti-Patterns in Migration
+
+| Anti-pattern | Why it's wrong | What to do instead |
+|---|---|---|
+| Keeping `PropertyFile` / `JsonGet` wrappers everywhere | Preserves the old DSL's complexity and hides ZenML's artifact model | Return typed artifacts and access them normally |
+| Treating runtime knobs as normal business parameters | Mixes infrastructure decisions with pipeline semantics | Move them into `SagemakerOrchestratorSettings` |
+| Silently translating `ConditionStep` to Python without explanation | Changes where and when the decision is made | Flag the semantic difference explicitly |
+| Translating `TuningStep` to one training run | Destroys the original optimization behavior | Keep HPO explicit |
+| Saying "Model Registry == MCP" | Misleads the user about governance semantics | Explain the difference and choose intentionally |
+| Saying "SageMaker Feature Store == ZenML feature store" | Overstates current support and leads to a bad migration plan | Keep SageMaker Feature Store explicit or treat it as custom integration work |
+| Claiming Lambda / callback semantics are preserved | They are not native ZenML concepts | Keep them as explicit AWS integrations or redesign |
+| Keeping raw S3 URIs for ordinary inter-step data flow | Throws away artifact lineage and caching benefits | Use artifacts unless AWS-native APIs require URIs |

--- a/skills/zenml-vertexai-migration/plugin.json
+++ b/skills/zenml-vertexai-migration/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "zenml-vertexai-migration",
+  "version": "1.0.0",
+  "description": "Migrate Vertex AI Pipelines (KFP v2 / PipelineJob workflows) to idiomatic ZenML pipelines with concept mapping, artifact-contract translation, GCPC rewrite guidance, and unsupported pattern flagging",
+  "author": {
+    "name": "ZenML Team",
+    "email": "hello@zenml.io",
+    "url": "https://github.com/zenml-io"
+  },
+  "homepage": "https://docs.zenml.io",
+  "repository": "https://github.com/zenml-io/skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "zenml",
+    "vertexai",
+    "vertex-ai",
+    "kubeflow",
+    "kfp",
+    "gcpc",
+    "migration",
+    "mlops",
+    "pipelines",
+    "orchestration"
+  ],
+  "skills": "./skills/"
+}

--- a/skills/zenml-vertexai-migration/skills/vertexai-migration/SKILL.md
+++ b/skills/zenml-vertexai-migration/skills/vertexai-migration/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: vertexai-to-zenml-migration
+description: >-
+  Migrate Vertex AI Pipelines (Kubeflow Pipelines v2 / PipelineJob workflows)
+  to idiomatic ZenML pipelines. Handles concept mapping
+  (`@dsl.pipeline` -> `@pipeline`, `@dsl.component` -> `@step`,
+  `PipelineJob.create_schedule(...)` -> `Schedule(...)`), artifact-contract
+  translation (`Input[Dataset]`, `InputPath`, `.uri`, `.path`),
+  Google Cloud Pipeline Components (GCPC) rewrites, dynamic control flow
+  (`dsl.If`, `dsl.ParallelFor`, `dsl.Collected`), resource/config migration,
+  and flags unsupported patterns (compiled template workflows, `dsl.ExitHandler`,
+  path-coupled artifacts, schedule lifecycle parity) for human review. Use this
+  skill whenever the user mentions Vertex AI Pipelines migration, KFP v2 to
+  ZenML, PipelineJob migration, GCPC migration, or asks how a Vertex/KFP concept
+  maps to ZenML — even if they do not explicitly say "migrate". Also use when
+  they paste KFP DSL code, compiled pipeline YAML/JSON, Vertex submission code,
+  or describe a workflow using Vertex/KFP terminology (`dsl.component`,
+  `dsl.pipeline`, `dsl.If`, `dsl.ParallelFor`, `PipelineJob`, GCPC) in a ZenML
+  context. If the user just asks a quick conceptual question ("what is the
+  ZenML equivalent of `dsl.importer`?"), answer it directly from the concept map
+  — no need to run the full migration workflow.
+---
+
+# Migrate Vertex AI Pipelines to ZenML
+
+This skill translates **Vertex AI Pipelines / KFP v2 / PipelineJob workflows** into idiomatic ZenML pipelines.
+
+The shape looks familiar at first: both systems use decorated Python functions, typed inputs and outputs, and DAG-style orchestration. But under the hood the story is different:
+
+- **KFP / Vertex** compiles Python into a pipeline template and treats artifacts as runtime-managed references with URIs and local paths.
+- **ZenML** executes from Python definitions and treats artifacts as Python values that are materialized into an artifact store.
+
+That means this migration is not a search-and-replace job. Some patterns map directly, some map approximately, and some must be treated as redesign boundaries.
+
+## How migration works at a high level
+
+For most teams, the safest migration story is:
+
+1. **Keep Vertex as the execution plane**
+2. **Add ZenML as the control plane**
+3. **Rewrite KFP / Vertex authoring concepts into ZenML-native pipelines**
+
+There are two practical strategies:
+
+- **Preferred**: full ZenML-native rewrite running on the ZenML Vertex orchestrator
+- **Fallback**: keep the compiled KFP template and wrap the `PipelineJob` submission inside a ZenML step as a temporary black-box migration
+
+The skill should optimize for the first strategy and document the second honestly as a partial migration escape hatch.
+
+### The three mapping types
+
+| Type | Meaning | Action |
+|------|---------|--------|
+| **Direct** | Clean 1:1 mapping exists | Translate automatically |
+| **Approximate** | Similar intent, different semantics | Translate with caveats and record the difference |
+| **Absent** | No ZenML equivalent | Flag for human review and suggest a redesign |
+
+See [references/concept-map.md](references/concept-map.md) for the full mapping tables.
+
+## The Migration Workflow
+
+### Phase 1: Receive and analyze the Vertex / KFP workflow
+
+Ask the user for the actual source artifacts before rewriting anything. In practice that may be:
+
+- KFP DSL source files
+- Vertex submission code using `PipelineJob(...)`
+- compiled YAML / JSON pipeline templates
+- GCPC usage
+- component code and helper modules
+
+Read all of it carefully and identify:
+
+1. **Pipeline structure** — `@dsl.pipeline`, subpipelines, graph helpers, imported components
+2. **Component types** — plain Python `@dsl.component`, `@dsl.container_component`, importer components, GCPC operators
+3. **Artifact contract** — `Input[T]`, `Output[T]`, `InputPath`, `OutputPath`, `.path`, `.uri`, metadata helpers
+4. **Control flow** — `dsl.If`, `dsl.Elif`, `dsl.Else`, `dsl.Condition`, `dsl.ParallelFor`, `dsl.Collected`, `dsl.ExitHandler`
+5. **Compile / template workflow** — `compiler.Compiler().compile()`, template registries, `template_path=...`, schedule creation from compiled templates
+6. **Scheduling** — `PipelineJob.create_schedule(...)`, cron strings, timezones, start/end windows, concurrency knobs
+7. **Infrastructure / runtime settings** — base image, packages, target image, CPU / memory / GPU settings, service accounts, network, persistent resources, labels, caching
+8. **Platform integrations** — Vertex Experiments, Model Registry, Endpoints, BigQuery, Dataflow, Dataproc, GCS, TensorBoard
+
+### Phase 2: Classify and plan
+
+Classify each concept as direct / approximate / absent using [references/concept-map.md](references/concept-map.md) and [references/gaps-and-flags.md](references/gaps-and-flags.md).
+
+#### Quick classification guide
+
+**Direct translations (translate automatically):**
+- `@dsl.pipeline` -> `@pipeline`
+- typed pipeline parameters -> typed pipeline function args
+- plain Python `@dsl.component` -> `@step` when the contract is value-centric
+- simple dataflow wiring -> step outputs passed directly into downstream step inputs
+
+**Approximate translations (translate with caveats):**
+- KFP artifacts -> typed ZenML artifacts / materializers
+- `InputPath` / `OutputPath` -> explicit file handling or a location-aware artifact contract
+- `dsl.If` on upstream outputs -> `@pipeline(dynamic=True)` + `.load()`
+- `dsl.ParallelFor` -> `.map()` in a dynamic pipeline
+- `dsl.Collected` -> reducer step over mapped outputs
+- importer components -> `ExternalArtifact(...)` or explicit artifact lookup
+- `PipelineJob.create_schedule(...)` -> `Schedule(...)`
+- resource setters -> `ResourceSettings(...)` plus Vertex-specific orchestrator settings
+- Vertex Experiments / Model Registry / Endpoint ops -> explicit SDK-calling steps
+
+**Absent / must-flag patterns (never silently approximate):**
+- GCPC operator catalog parity
+- compiled-template publishing workflows
+- `dsl.ExitHandler`
+- schedule lifecycle parity from ZenML back into Vertex
+- automatic Vertex Model Registry parity
+- automatic Vertex Experiment parity
+- artifact contracts that fundamentally depend on KFP-managed paths / URIs / placeholders
+
+#### Present the migration plan
+
+Before writing code, summarize the findings for the user:
+
+> "Here is what I found in your Vertex / KFP pipeline:
+> - **Direct translations**: [list]
+> - **Approximate translations**: [list]
+> - **Needs redesign**: [list]
+>
+> The main risk areas are [artifact contract / GCPC / control flow / template lifecycle]. Shall I proceed with the migration?"
+
+If there are high-risk flags, explain them concretely in story form: what the original KFP code does, why ZenML cannot preserve that behavior 1:1, and what the least-bad redesign looks like.
+
+### Phase 3: Generate ZenML code
+
+Translate the workflow into a ZenML project. Follow these conventions strictly.
+
+#### Project structure
+
+Every migrated project MUST use this layout:
+
+```text
+migrated_pipeline/
+├── steps/                    # One file per step
+│   ├── extract.py
+│   ├── train.py
+│   └── deploy.py
+├── pipelines/
+│   └── my_pipeline.py
+├── materializers/            # Custom materializers when path/URI semantics matter
+├── configs/
+│   ├── dev.yaml
+│   └── prod.yaml
+├── run.py                    # CLI entry point (argparse, not click)
+├── README.md
+└── pyproject.toml
+```
+
+Key rules:
+
+- One step per file in `steps/`
+- Keep pipeline definition separate from execution
+- `run.py` uses `argparse`
+- `pyproject.toml` uses `zenml>=0.94.1` and `requires-python = ">=3.12"`
+- Always generate `configs/dev.yaml` and `configs/prod.yaml`
+- Always generate a `README.md`
+- Run `zenml init` at the project root
+
+#### Translation rules that matter most
+
+**1. Artifact-contract-first translation**
+
+Do not start by translating decorators. Start by asking what the step *really* exchanges.
+
+- If `.path` / `.uri` is only a serialization boundary, convert to a normal Python type and let ZenML materialize it.
+- If the code depends on location identity, directory layout, sibling files, or passing artifact paths to an external binary, keep that as an explicit contract and use a custom materializer, reference object, or controlled file-handling pattern.
+
+**2. GCPC rewrite rule**
+
+Never pretend ZenML has a matching GCPC operator.
+
+- GCPC nodes must become ordinary ZenML steps
+- Those steps should call the relevant SDK / API directly
+- Mark every such translation as a **rewrite**, not a direct translation
+
+**3. Control-flow rule**
+
+- Static `if` is only safe when the condition depends on pipeline parameters
+- Runtime branching on upstream outputs requires `@pipeline(dynamic=True)` plus `.load()`
+- `dsl.ParallelFor` should map to `.map()` only when the resulting dynamic-pipeline semantics are acceptable
+
+**4. Compile / template rule**
+
+- Do not keep `compiler.Compiler().compile()` in migrated ZenML code
+- If the user must keep template-based submission, that is a **partial migration**
+- In that partial migration, wrap the existing `PipelineJob` submission in a ZenML step and be explicit that ZenML sees it as one black-box node
+
+**5. Comment style**
+
+Use concise migration comments:
+
+- `# Migration note:` for semantic caveats
+- `# TODO(migration):` for required user action
+
+Keep detailed prose in the migration report, not in the code.
+
+#### Handling approximate translations
+
+When semantics change, leave a short inline note:
+
+```python
+@step
+def evaluate_model(metrics_path_hint: str | None = None) -> dict[str, float]:
+    # Migration note: the original KFP component wrote metrics to a managed
+    # artifact path. This ZenML step returns metrics as a typed artifact instead.
+    return {"accuracy": 0.91}
+```
+
+#### Handling absent patterns
+
+For unsupported patterns:
+
+1. Add a `# TODO(migration):` comment in code
+2. Record it in the migration report
+3. Suggest a redesign
+
+```python
+# TODO(migration): UNSUPPORTED — original pipeline relied on dsl.ExitHandler
+# to guarantee cleanup after failure. ZenML has no exact equivalent.
+# Redesign this as idempotent cleanup plus hooks / external failure handling.
+```
+
+### Phase 4: Produce the migration report
+
+After generating the project, always create `MIGRATION_REPORT.md` in the project root.
+
+Use this structure:
+
+```markdown
+# Migration Report: [Vertex Pipeline] -> [ZenML Pipeline]
+
+## Summary
+- **Source**: Vertex AI Pipelines / KFP v2 workflow `[name]`
+- **Target**: ZenML pipeline `[pipeline_name]`
+- **Steps migrated**: X direct, Y approximate, Z flagged
+
+## Direct Translations
+| Source Concept | ZenML Target | Notes |
+
+## Approximate Translations
+| Source Concept | ZenML Target | What Changed |
+
+## Flagged for Review
+| Pattern | Severity | Issue | Suggested Redesign |
+
+## Artifact Contract Decisions
+| Source Component | Old Contract | New Contract | Notes |
+
+## GCPC Rewrite Summary
+| GCPC Node | Replacement Step | SDK / API Used | Notes |
+
+## Vertex Platform Integration Mapping
+| Vertex Feature | ZenML Mapping | Notes |
+
+## Compiled Template / Schedule Lifecycle Gaps
+- [list exactly what is not preserved]
+
+## What's NOT Migrated
+- template registries
+- Vertex schedule lifecycle management
+- Vertex Model Registry parity unless explicitly implemented
+- Vertex Experiment wiring unless explicitly configured
+- ML Metadata equivalence
+
+## What You Get for Free After Migration
+- artifact versioning and lineage
+- stack portability
+- step caching
+- model / artifact control-plane capabilities
+- a cleaner separation between pipeline logic and cloud SDK calls
+
+## Recommended Next Steps
+1. Run `zenml-quick-wins`
+2. Install the ZenML docs MCP server
+3. Validate the migrated pipeline on the ZenML Vertex orchestrator
+4. Run the same pipeline on a second stack if portability matters
+5. Run `/simplify` on the generated code
+```
+
+### Phase 5: Suggest next steps
+
+After migration, always guide the user toward the next layer of cleanup and hardening.
+
+#### 1. Run `zenml-quick-wins`
+
+Say this explicitly:
+
+> "Now that the migration is done, I recommend running `zenml-quick-wins` to add metadata logging, experiment tracking, secrets, and other production features."
+
+#### 2. Link the user to the right ZenML docs
+
+When relevant, include specific links:
+
+- Vertex orchestrator: `https://docs.zenml.io/stacks/stack-components/orchestrators/vertex`
+- Scheduling: `https://docs.zenml.io/concepts/steps_and_pipelines/scheduling`
+- Dynamic pipelines: `https://docs.zenml.io/concepts/steps_and_pipelines/dynamic_pipelines`
+- External artifacts: `https://docs.zenml.io/user-guides/starter-guide/manage-artifacts#consuming-external-artifacts-within-a-pipeline`
+- Materializers: `https://docs.zenml.io/concepts/artifacts/materializers`
+- Experiment trackers: `https://docs.zenml.io/stacks/stack-components/experiment-trackers`
+
+#### 3. Suggest the docs MCP server
+
+> "For easier access to current ZenML docs while you refine the migration, install the docs MCP server: `claude mcp add zenmldocs --transport http https://docs.zenml.io/~gitbook/mcp`"
+
+#### 4. Offer community escalation for real gaps
+
+When there are **2+ HIGH-severity flags**, generate a copy-pasteable Slack message for `zenml.io/slack` summarizing:
+
+- what is being migrated
+- which patterns failed to map cleanly
+- what redesigns were attempted
+- what help the user needs
+
+#### 5. Offer GitHub issue creation for genuine product gaps
+
+If the migration exposes a real missing feature in ZenML, offer to open an issue on `zenml-io/zenml` with:
+
+- the original Vertex / KFP pattern
+- why it matters
+- what workaround was attempted
+- what a useful feature would look like
+
+#### 6. Suggest `/simplify`
+
+Migration output is often correct but bulky. Always suggest `/simplify` to remove scaffolding comments, reduce duplication, and make the code feel production-ready.
+
+## Important behavioral differences to communicate
+
+These are the places where users are most likely to think "this looks the same" when it is not the same.
+
+### Artifact model
+
+KFP artifacts are runtime-managed references with `.path`, `.uri`, and metadata attached. ZenML artifacts are Python values loaded and saved by materializers.
+
+Practical consequence: a KFP `Input[Dataset]` is not automatically the same as a ZenML `pd.DataFrame`. Sometimes it is. Sometimes that translation erases the real contract.
+
+### Pipeline execution model
+
+KFP authoring usually ends in compilation and submission of a template. ZenML runs from Python definitions through its orchestrator abstraction.
+
+Practical consequence: compiled-template workflows, template registries, and `template_path=...` usage are redesign boundaries.
+
+### Control flow
+
+KFP runtime branching and fan-out are backend orchestration concepts. ZenML can do similar work with dynamic pipelines, but the mechanics differ.
+
+Practical consequence: never translate `dsl.If` into a plain Python `if` in a static pipeline, and never translate `dsl.ParallelFor` into a plain `for` loop if you need backend fan-out semantics.
+
+### Scheduling
+
+Vertex exposes richer schedule lifecycle and concurrency controls than ZenML’s generic `Schedule(...)` surface.
+
+Practical consequence: cron schedule creation may migrate, but full lifecycle parity usually does not.
+
+### Experiments, model registry, and metadata
+
+Vertex Experiments, Vertex Model Registry, and Vertex ML Metadata overlap with ZenML concepts, but they are not the same objects or the same metadata plane.
+
+Practical consequence: migrate the *intent* explicitly. Do not tell the user that ZenML artifacts automatically become Vertex Model resources or that ZenML metadata is the same thing as Vertex MLMD.
+
+## Anti-patterns in migration
+
+| Anti-pattern | Why it is wrong | What to do instead |
+|---|---|---|
+| Translating every `Input[Dataset]` to `pd.DataFrame` | Erases URI/path semantics when the original component was location-aware | Classify the artifact contract first |
+| Pretending GCPC has ZenML equivalents | ZenML has no GCPC-style operator catalog | Rewrite as SDK-calling steps |
+| Keeping `compiler.Compiler().compile()` in migrated code | ZenML does not need user-facing compilation | Remove it, or treat compiled-template submission as a partial migration |
+| Replacing `dsl.ParallelFor` with a plain `for` loop | Loses backend fan-out and observability | Use dynamic pipelines with `.map()` when appropriate |
+| Replacing runtime `dsl.If` with static Python branching | Changes control-flow semantics | Use `dynamic=True` plus `.load()` |
+| Treating `dsl.ExitHandler` as "just add a last step" | Exit handlers can run after failure; a last step may never run | Redesign cleanup / notification semantics explicitly |
+| Assuming ZenML model artifacts equal Vertex Model resources | They are different resource models | Add an explicit model-upload step if Vertex Model Registry matters |
+| Assuming ZenML schedule updates delete/update Vertex schedules | ZenML does not fully manage Vertex schedule lifecycle | Document manual schedule management |
+| Assuming caching semantics are identical | Cache identity and execution model differ | Revalidate caching behavior after migration |
+
+## References
+
+### Detailed reference files
+
+- [references/concept-map.md](references/concept-map.md) — Full concept mapping tables, scheduling support notes, and platform feature mapping
+- [references/code-patterns.md](references/code-patterns.md) — Concrete KFP / Vertex -> ZenML translation patterns for the major migration surfaces
+- [references/gaps-and-flags.md](references/gaps-and-flags.md) — Must-flag patterns, artifact contract classification, behavioral differences, and migration decision tree
+
+### ZenML documentation
+
+For topics beyond migration, query the ZenML docs at https://docs.zenml.io.

--- a/skills/zenml-vertexai-migration/skills/vertexai-migration/references/code-patterns.md
+++ b/skills/zenml-vertexai-migration/skills/vertexai-migration/references/code-patterns.md
@@ -1,0 +1,397 @@
+# Vertex AI Pipelines / KFP v2 → ZenML Code Patterns
+
+Concrete translation patterns for the most common migration surfaces. These examples are intentionally opinionated: they optimize for **idiomatic ZenML**, not for preserving the KFP authoring model at any cost. Some sections are close-to-runnable skeletons; others are structural patterns that show the migration shape and the contract decisions you need to make.
+
+## 1. Simple typed pipeline
+
+```python
+# KFP / Vertex
+from kfp import dsl
+
+@dsl.component
+def load_dataset() -> dsl.Dataset:
+    ...
+
+@dsl.component
+def train_model(dataset: dsl.Dataset) -> dsl.Model:
+    ...
+
+@dsl.pipeline
+def training_pipeline(project: str) -> None:
+    dataset = load_dataset()
+    train_model(dataset=dataset.output)
+```
+
+```python
+# ZenML
+from typing import Annotated
+import pandas as pd
+from zenml import pipeline, step
+
+@step
+def load_dataset() -> Annotated[pd.DataFrame, "dataset"]:
+    ...
+
+@step
+def train_model(dataset: pd.DataFrame) -> Annotated[object, "model"]:
+    ...
+
+@pipeline
+def training_pipeline(project: str) -> None:
+    dataset = load_dataset()
+    train_model(dataset)
+```
+
+**Key differences**
+- KFP artifacts are references; ZenML artifacts are materialized Python values.
+- This translation is safe only when the old component treated the artifact as data, not as a meaningful URI/path.
+
+## 2. Python function-based component translation
+
+```python
+# KFP / Vertex
+from kfp import dsl
+
+@dsl.component(
+    base_image="python:3.12",
+    packages_to_install=["pandas==2.2.3", "scikit-learn==1.6.1"],
+)
+def preprocess(input_uri: str) -> str:
+    ...
+```
+
+```python
+# ZenML
+from zenml import step
+from zenml.config import DockerSettings
+
+@step(settings={"docker": DockerSettings(
+    parent_image="python:3.12",
+    requirements=["pandas==2.2.3", "scikit-learn==1.6.1"],
+)})
+def preprocess(input_uri: str) -> str:
+    ...
+```
+
+**Translation notes**
+- Move image/dependency concerns into `DockerSettings`.
+- Keep portable logic in the step body; keep platform-specific infra outside it.
+
+## 3. Container-based component translation
+
+```python
+# KFP / Vertex
+from kfp.dsl import container_component, ContainerSpec
+
+@container_component
+def score_model(model_uri: str, data_uri: str):
+    return ContainerSpec(
+        image="gcr.io/acme/scorer:latest",
+        command=["python", "/app/score.py"],
+        args=["--model", model_uri, "--data", data_uri],
+    )
+```
+
+```python
+# ZenML
+from zenml import step
+
+@step
+def score_model(model_uri: str, data_uri: str) -> str:
+    # Migration note: original component was a container contract, not a normal
+    # Python function. This ZenML step is a wrapper around that container logic.
+    ...
+```
+
+**Migration warning**
+- This is an approximation, not a direct translation.
+- If the container interface is complex, non-Python, or tightly coupled to KFP placeholders, stop and redesign.
+
+## 4. `dsl.If` / runtime branching
+
+```python
+# KFP / Vertex
+from kfp import dsl
+
+@dsl.pipeline
+def pipeline():
+    score = evaluate_model()
+    with dsl.If(score.output > 0.9):
+        deploy_model()
+```
+
+```python
+# ZenML
+from zenml import pipeline
+
+@pipeline(dynamic=True)
+def pipeline() -> None:
+    score = evaluate_model()
+    if score.load() > 0.9:
+        deploy_model()
+```
+
+**Migration warning**
+- Do not convert a runtime KFP condition into a plain `if` inside a static ZenML pipeline.
+- `.load()` changes where the decision is made and must be treated as a semantic change worth documenting.
+
+## 5. `dsl.ParallelFor` + `dsl.Collected`
+
+```python
+# KFP / Vertex
+from kfp import dsl
+
+@dsl.pipeline
+def batch_pipeline():
+    items = list_items()
+    with dsl.ParallelFor(items.output) as item:
+        result = process_item(item=item)
+    aggregate(results=dsl.Collected(result.output))
+```
+
+```python
+# ZenML
+from zenml import pipeline
+
+@pipeline(dynamic=True)
+def batch_pipeline() -> None:
+    items = list_items()
+    results = process_item.map(item=items)
+    aggregate(results)
+```
+
+**Key differences**
+- `.map()` is the closest match, but not identical to KFP fan-out semantics.
+- Ordering, retry behavior, and observability must be revalidated after migration.
+
+## 6. Pipeline parameters / `PipelineJob` submission
+
+```python
+# KFP / Vertex
+from google.cloud import aiplatform
+
+job = aiplatform.PipelineJob(
+    display_name="training",
+    template_path="compiled.yaml",
+    parameter_values={"project": "acme-prod"},
+)
+job.run()
+```
+
+```python
+# ZenML
+from zenml import pipeline
+
+@pipeline
+def training_pipeline(project: str) -> None:
+    ...
+
+training_pipeline(project="acme-prod")
+```
+
+**Translation notes**
+- In a full migration, the compile boundary disappears.
+- If the team must keep `template_path=...`, that is a partial migration: wrap the existing submission in a ZenML step and document the loss of step-level lineage inside the KFP sub-pipeline.
+
+## 7. Caching configuration
+
+```python
+# KFP / Vertex
+task = train_model()
+task.set_caching_options(False)
+```
+
+```python
+# ZenML
+from zenml import step
+
+@step(enable_cache=False)
+def train_model():
+    ...
+```
+
+**Key differences**
+- Both systems support caching, but cache identity differs.
+- Never promise that cache hits will line up exactly after migration.
+
+## 8. Resource and GPU specification
+
+```python
+# KFP / Vertex
+task = train_model()
+task.set_cpu_limit("8")
+task.set_memory_limit("32G")
+task.set_accelerator_type("NVIDIA_TESLA_T4")
+task.set_accelerator_limit(1)
+```
+
+```python
+# ZenML
+from zenml import step
+from zenml.config import ResourceSettings
+
+@step(settings={"resources": ResourceSettings(
+    cpu_count=8,
+    memory="32GB",
+    gpu_count=1,
+)})
+def train_model():
+    ...
+```
+
+**Translation notes**
+- `ResourceSettings(...)` captures portable intent first.
+- Add Vertex-specific orchestrator settings only for details that genuinely need them, such as machine type, service account, network, or persistent resources.
+
+## 9. GCPC rewrite pattern: BigQuery
+
+```python
+# KFP / Vertex (structural pattern)
+from google_cloud_pipeline_components.v1.bigquery import BigqueryQueryJobOp
+
+query = BigqueryQueryJobOp(
+    query="SELECT * FROM my_table",
+    project="acme-prod",
+)
+```
+
+```python
+# ZenML
+from zenml import step
+
+@step
+def run_bigquery_query(query: str, project: str) -> str:
+    # Migration note: this is a rewrite of a GCPC node into ordinary SDK code.
+    from google.cloud import bigquery
+
+    client = bigquery.Client(project=project)
+    job = client.query(query)
+    job.result()
+    return str(job.job_id)
+```
+
+**Migration warning**
+- Rewrite, not translation.
+- Verify auth, permissions, and output-artifact handling explicitly.
+
+## 10. GCPC rewrite pattern: Vertex training / AutoML
+
+```python
+# KFP / Vertex (structural pattern)
+from google_cloud_pipeline_components.v1.automl.training_job import (
+    AutoMLTabularTrainingJobRunOp,
+)
+
+train = AutoMLTabularTrainingJobRunOp(...)
+```
+
+```python
+# ZenML
+from zenml import step
+
+@step
+def launch_vertex_training(project: str, region: str, dataset_uri: str) -> str:
+    # Migration note: original GCPC operator has been replaced with an explicit
+    # Vertex AI SDK call.
+    from google.cloud import aiplatform
+
+    aiplatform.init(project=project, location=region)
+    ...
+    return "vertex-training-job-id"
+```
+
+**Migration warning**
+- Keep the cloud API call explicit so the user can see exactly what still depends on Vertex.
+- Do not claim there is a native ZenML AutoML operator.
+
+## 11. Endpoint deployment / model registry
+
+```python
+# ZenML
+from zenml import step
+
+@step
+def upload_and_deploy_model(project: str, region: str, model_artifact_uri: str) -> str:
+    from google.cloud import aiplatform
+
+    aiplatform.init(project=project, location=region)
+    # Upload model / create endpoint / deploy explicitly here.
+    ...
+    return "endpoint-id"
+```
+
+**Translation notes**
+- ZenML model artifacts and Vertex Model Registry resources are different objects.
+- Keep the handoff explicit.
+
+## 12. Scheduling
+
+```python
+# KFP / Vertex
+job.create_schedule(
+    cron="TZ=Europe/Amsterdam 0 3 * * *",
+    start_time="2026-04-08T00:00:00Z",
+    end_time="2026-05-08T00:00:00Z",
+)
+```
+
+```python
+# ZenML
+from datetime import datetime, timezone
+from zenml.config.schedule import Schedule
+
+training_pipeline.with_options(
+    schedule=Schedule(
+        cron_expression="TZ=Europe/Amsterdam 0 3 * * *",
+        start_time=datetime(2026, 4, 8, tzinfo=timezone.utc),
+        end_time=datetime(2026, 5, 8, tzinfo=timezone.utc),
+    )
+)()
+```
+
+**Migration warning**
+- ZenML exposes the common subset only.
+- Schedule update/delete lifecycle still needs manual validation on Vertex.
+
+## 13. Importer / external artifact
+
+```python
+# KFP / Vertex
+from kfp import dsl
+
+existing_dataset = dsl.importer(
+    artifact_uri="gs://acme-data/raw/train.parquet",
+    artifact_class=dsl.Dataset,
+)
+```
+
+```python
+# ZenML
+from zenml import ExternalArtifact, pipeline
+
+@pipeline
+def training_pipeline() -> None:
+    raw_dataset = ExternalArtifact(value="gs://acme-data/raw/train.parquet")
+    train_model(raw_dataset)
+```
+
+**Key differences**
+- In KFP the importer registers an artifact node in the compiled graph.
+- In ZenML you inject or register the external value explicitly.
+
+## 14. Experiment tracking / metrics
+
+```python
+# ZenML
+from typing import Annotated
+from zenml import step
+
+@step
+def evaluate_model() -> Annotated[dict[str, float], "metrics"]:
+    metrics = {"accuracy": 0.93, "f1": 0.91}
+    return metrics
+```
+
+**Translation notes**
+- Use artifacts and metadata logging for metrics.
+- Add a Vertex experiment tracker if the user wants metrics and run links to surface in Vertex Experiments explicitly.

--- a/skills/zenml-vertexai-migration/skills/vertexai-migration/references/concept-map.md
+++ b/skills/zenml-vertexai-migration/skills/vertexai-migration/references/concept-map.md
@@ -1,0 +1,126 @@
+# Vertex AI Pipelines / KFP v2 → ZenML Concept Map
+
+Complete mapping of **Vertex AI Pipelines / KFP v2 / PipelineJob workflows** to ZenML. Each entry is classified as **direct** (clean 1:1 mapping), **approximate** (similar intent, different semantics), or **absent** (no ZenML equivalent — redesign required).
+
+## Table of Contents
+
+- [Core Pipeline](#core-pipeline)
+- [Artifact Types](#artifact-types)
+- [Control Flow](#control-flow)
+- [Google Cloud Pipeline Components](#google-cloud-pipeline-components)
+- [Scheduling and Triggers](#scheduling-and-triggers)
+- [Infrastructure and Resources](#infrastructure-and-resources)
+- [Vertex AI Platform Features](#vertex-ai-platform-features)
+
+## Core Pipeline
+
+| KFP / Vertex concept | ZenML equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `@dsl.pipeline` | `@pipeline` | direct | Both define the pipeline graph in Python. |
+| typed pipeline parameters | typed pipeline function arguments | direct | This part migrates cleanly. |
+| `@dsl.component` | `@step` | approximate | Similar shape, different execution and artifact semantics. |
+| `@dsl.component(base_image=..., packages_to_install=...)` | `@step(settings={"docker": DockerSettings(...)})` | approximate | Same intent, different build/runtime model. |
+| `@dsl.component(target_image=...)` | `DockerSettings(parent_image=...)` or a prebuilt image workflow | approximate | The image toolchain is different. |
+| `@dsl.container_component` | wrapper `@step` plus containerization logic | approximate | Safe only when the container contract is simple and explicit. |
+| `ContainerSpec` | wrapper step + ZenML container settings | approximate | Redesign-heavy when the original component is not really a Python function. |
+| `Input[T]` / `Output[T]` | typed step inputs and return values | approximate | KFP types platform artifacts; ZenML types Python values. |
+| `InputPath` / `OutputPath` | explicit file handling, `ExternalArtifact`, `UnmaterializedArtifact`, or a custom materializer | approximate | Path identity is not a first-class ZenML step contract. |
+| `dsl.importer(...)` | `ExternalArtifact(...)` or explicit artifact lookup / registration | approximate | Similar intent, different mechanism. |
+| `PipelineTask.after()` | explicit ordering or artifact dependency | approximate | Artifact edges remain the preferred dependency signal. |
+| `compiler.Compiler().compile()` | none | absent | ZenML does not require user-facing compilation. |
+| compiled IR YAML / JSON | none | absent | ZenML snapshots are not KFP pipeline templates. |
+| placeholder helpers such as `PIPELINE_ROOT_PLACEHOLDER` | explicit config or artifact APIs | absent | Placeholder-driven path injection does not have a direct DSL match. |
+
+## Artifact Types
+
+| KFP artifact type | ZenML equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `Artifact` | custom Python type plus materializer | approximate | Use the real contract, not a fake generic placeholder. |
+| `Dataset` | `pd.DataFrame`, dataset class, `Path`, or URI/reference object | approximate | Do not flatten URI-aware datasets into DataFrames blindly. |
+| `Model` | model object artifact or explicit model-upload step | approximate | ZenML model artifacts are not Vertex Model Registry resources. |
+| `Metrics` | `dict[str, float]` and/or metadata logging | approximate | Same goal, different API. |
+| `ClassificationMetrics` | structured Python object plus metadata logging | approximate | Preserve the schema explicitly. |
+| `SlicedClassificationMetrics` | structured Python object plus metadata logging | approximate | Keep slice structure stable and explicit. |
+| `HTML` | `str`, `Path`, or a visualizable custom artifact | approximate | Validate UI rendering expectations after migration. |
+| `Markdown` | `str`, `Path`, or a visualizable custom artifact | approximate | Same caution as HTML. |
+| `InputPath(T)` / `OutputPath(T)` | explicit temp-file handling or a location-aware artifact contract | approximate | Treat as a contract decision, not a decorator rename. |
+
+## Control Flow
+
+| KFP / Vertex concept | ZenML equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `dsl.Condition` | `@pipeline(dynamic=True)` plus Python branching on `.load()` | approximate | Similar intent, different execution model. |
+| `dsl.If` / `dsl.Elif` / `dsl.Else` | dynamic-pipeline branching | approximate | Safe only when you preserve runtime-vs-static semantics explicitly. |
+| `dsl.OneOf` | selector step or ordinary Python branching | approximate | No dedicated ZenML primitive. |
+| `dsl.ParallelFor` | `.map()` in a dynamic pipeline | approximate | Similar fan-out, different semantics and limitations. |
+| `dsl.Collected` | reducer step over mapped outputs | approximate | Similar fan-in, different runtime model. |
+| artifact-driven loops | `.load()` for control flow and `.map()` for fan-out | approximate | ZenML separates control decisions from artifact edges. |
+| explicit async submission patterns | `.submit()` where appropriate | approximate | Use sparingly and document why. |
+| `dsl.ExitHandler` | none | absent | Redesign cleanup / notification semantics explicitly. |
+| final-status driven cleanup semantics | hooks, idempotent cleanup, or external failure handling | absent | Not a 1:1 pipeline primitive in ZenML. |
+
+## Google Cloud Pipeline Components
+
+All GCPC families should be treated as **rewrite-only** surfaces.
+
+| GCPC family / example op | ZenML migration target | Mapping | Notes |
+|---|---|:---:|---|
+| BigQuery (`BigqueryQueryJobOp`) | `@step` calling BigQuery client / SQL API | absent | Rewrite as ordinary Python step code. |
+| AutoML (`AutoMLTabularTrainingJobRunOp`) | `@step` calling Vertex AI SDK | absent | No ZenML operator parity. |
+| Model upload (`ModelUploadOp`) | explicit SDK-calling upload step | absent | ZenML model artifacts are not Vertex Model resources. |
+| Endpoint create / deploy (`EndpointCreateOp`, `ModelDeployOp`) | explicit SDK-calling deployment step | absent | Rewrite the cloud action explicitly. |
+| Batch prediction | explicit SDK-calling step | absent | Preserve intent, not operator syntax. |
+| Dataflow (`DataflowPythonJobOp`) | explicit Beam/Dataflow launch step | absent | This is orchestration over a service, not a native ZenML operator. |
+| Dataproc jobs | explicit Dataproc API step | absent | Same rewrite rule. |
+| hyperparameter tuning ops | explicit SDK-calling tuning step | absent | Model as step code or split into separate orchestration. |
+
+## Scheduling and Triggers
+
+| KFP / Vertex concept | ZenML equivalent | Mapping | Notes |
+|---|---|:---:|---|
+| `PipelineJob.create_schedule(...)` | `Schedule(cron_expression=..., start_time=..., end_time=...)` | approximate | ZenML exposes the common subset, not full lifecycle parity. |
+| timezone-prefixed cron | `Schedule(cron_expression="TZ=... ...")` | approximate | Validate the exact cron form against your target orchestrator. |
+| `max_run_count` / `max_concurrent_run_count` / queueing knobs | none | absent | These are not first-class ZenML schedule settings. |
+| schedule update / delete via Vertex APIs | manual management on the orchestrator side | absent | ZenML does not fully manage Vertex schedule lifecycle. |
+| template-path-based scheduling | none | absent | ZenML schedules pipelines, not compiled KFP templates. |
+
+### Orchestrator scheduling support
+
+| Orchestrator | Scheduling | Types Supported | Native schedule management |
+|---|:---:|---|:---:|
+| Airflow | Yes | Cron, Interval | No |
+| AzureML | Yes | Cron, Interval | No |
+| Databricks | Yes | Cron only | No |
+| Kubeflow | Yes | Cron, Interval | No |
+| Kubernetes | Yes | Cron only | Yes |
+| SageMaker | Yes | Cron, Interval, One-time | No |
+| Vertex | Yes | Cron only | No |
+| Local / LocalDocker | No | — | — |
+
+## Infrastructure and Resources
+
+| KFP / Vertex mechanism | ZenML mechanism | Mapping | Notes |
+|---|---|:---:|---|
+| `set_cpu_limit`, `set_memory_limit`, `set_accelerator_limit` | `ResourceSettings(cpu_count=..., memory=..., gpu_count=...)` | approximate | Start with portable intent first. |
+| `set_accelerator_type` | Vertex-specific orchestrator settings | approximate | Keep backend-specific details separate from business logic. |
+| `add_node_selector_constraint()` | pod / orchestrator settings | approximate | Placement semantics are backend-specific. |
+| `base_image` / `packages_to_install` | `DockerSettings(...)` | approximate | Same problem solved through a different build system. |
+| `target_image` | prebuilt image or Docker parent image settings | approximate | Different toolchain boundary. |
+| service account on `PipelineJob.run(...)` | Vertex orchestrator settings / service connector-backed auth | direct | Supported, but configured differently. |
+| network / reserved IP ranges | Vertex-specific custom job parameters | approximate | These stay backend-specific. |
+| persistent resources | Vertex-specific custom job parameters | direct | Supported, but only on the Vertex path. |
+| `pipeline_root` | artifact store configuration in the active stack | approximate | Prefer stack config over hardcoded pipeline paths. |
+| KFP / Vertex caching flags | ZenML step / pipeline caching | approximate | Same goal, different cache identity model. |
+
+## Vertex AI Platform Features
+
+| Vertex AI feature | ZenML mapping | Mapping | Notes |
+|---|---|:---:|---|
+| managed execution on Vertex | Vertex orchestrator | direct | This is the main keep-Vertex migration path. |
+| Vertex run UI URL | orchestrator metadata / run links | approximate | Preserved in practice, but through ZenML metadata. |
+| Vertex Experiments | Vertex experiment tracker integration plus explicit logging | approximate | Similar intent, different wiring. |
+| TensorBoard integration | explicit experiment-tracker / SDK setup | approximate | Not automatic from ordinary artifact logging. |
+| Vertex Model Registry | explicit upload / deployment steps | approximate | Must be added intentionally. |
+| Vertex ML Metadata | ZenML metadata store + underlying Vertex metadata plane | approximate | Different canonical metadata systems. |
+| pipeline templates / template registry | none | absent | ZenML has no 1:1 template-registry concept. |
+| GCPC launch optimizations | none | absent | Rewritten SDK-calling steps can change startup / cost characteristics. |

--- a/skills/zenml-vertexai-migration/skills/vertexai-migration/references/gaps-and-flags.md
+++ b/skills/zenml-vertexai-migration/skills/vertexai-migration/references/gaps-and-flags.md
@@ -1,0 +1,249 @@
+# Gaps, Flags, and Behavioral Differences
+
+This reference covers the places where a naive Vertex / KFP -> ZenML translation silently changes behavior. These are the boundaries the migration skill must not cross without explicitly telling the user.
+
+## Table of Contents
+
+- [Must-Flag Patterns](#must-flag-patterns)
+- [Artifact Contract Classification Guide](#artifact-contract-classification-guide)
+- [Behavioral Differences](#behavioral-differences)
+- [Migration Decision Tree](#migration-decision-tree)
+- [ZenML Features with No Vertex Equivalent](#zenml-features-with-no-vertex-equivalent)
+
+---
+
+## Must-Flag Patterns
+
+These patterns must **never** be silently approximated.
+
+### GCPC operators
+
+**What Vertex / KFP does**: GCPC gives you prebuilt KFP components for BigQuery, AutoML, Model Upload, Endpoint Deploy, Batch Prediction, Dataflow, Dataproc, and more.
+
+**Why it matters**: These are not just helper functions. They are part of the KFP / Vertex authoring layer.
+
+**ZenML gap**: ZenML has no GCPC-style operator catalog.
+
+**Safe redesign**: Rewrite each GCPC node as an ordinary ZenML step that calls the relevant Google Cloud SDK or API directly.
+
+### Path- and URI-coupled artifact contracts
+
+**What Vertex / KFP does**: Components commonly use `.path`, `.uri`, `InputPath`, and `OutputPath` as real runtime contracts.
+
+**Why it matters**: If you flatten that contract into a DataFrame or dict blindly, you may erase directory layout, sibling files, or location identity.
+
+**ZenML gap**: ZenML’s default contract is Python values plus materializers.
+
+**Safe redesign**: First classify the component as value-centric, location-aware, or template/platform-coupled. Use custom materializers or explicit URI contracts where needed.
+
+### Compiled templates and template registries
+
+**What Vertex / KFP does**: Pipelines can be compiled, uploaded, versioned, and scheduled from a template path.
+
+**Why it matters**: Some teams are really using a template distribution workflow, not just a pipeline definition.
+
+**ZenML gap**: ZenML does not have a 1:1 "compiled template registry" concept.
+
+**Safe redesign**: Prefer a ZenML-native rewrite. If templates must stay, wrap the existing `PipelineJob` submission in a single ZenML step and call it a partial migration.
+
+### Runtime branching semantics
+
+**What Vertex / KFP does**: `dsl.If` / `dsl.Condition` can branch on upstream outputs at runtime.
+
+**Why it matters**: Turning that into a static Python `if` changes the graph and the execution story.
+
+**ZenML gap**: Runtime branching requires dynamic pipelines and `.load()`, not static graph construction.
+
+**Safe redesign**: Use `@pipeline(dynamic=True)` and document the semantic change explicitly.
+
+### `dsl.ParallelFor` and `dsl.Collected`
+
+**What Vertex / KFP does**: fans out work at the orchestration layer and later fans it back in.
+
+**Why it matters**: Replacing it with a plain `for` loop serializes work and changes observability and retry semantics.
+
+**ZenML gap**: `.map()` is the closest match, but not identical.
+
+**Safe redesign**: Use dynamic pipelines and `.map()` only when the semantics are good enough; otherwise redesign the workflow.
+
+### `dsl.ExitHandler`
+
+**What Vertex / KFP does**: provides exit-task behavior after a scoped block, often for cleanup or notifications.
+
+**Why it matters**: Users often rely on this for "always run" behavior even on failure.
+
+**ZenML gap**: No exact equivalent.
+
+**Safe redesign**: Use idempotent cleanup, hooks, or external failure handling. Never tell the user this is a direct translation.
+
+### Vertex schedule lifecycle and concurrency knobs
+
+**What Vertex / KFP does**: native schedule creation includes extra lifecycle and concurrency controls.
+
+**Why it matters**: Teams may depend on those knobs operationally.
+
+**ZenML gap**: `Schedule(...)` exposes only the common subset.
+
+**Safe redesign**: Migrate the cron/start/end parts and document the rest as manual follow-up.
+
+### Vertex Experiments / Model Registry assumptions
+
+**What Vertex / KFP does**: experiment association and model resources are explicit platform objects.
+
+**Why it matters**: Users may think those features are preserved automatically once the code compiles.
+
+**ZenML gap**: Similar intent, different resource model.
+
+**Safe redesign**: Add explicit tracker wiring and explicit upload / deploy steps where needed.
+
+---
+
+## Artifact Contract Classification Guide
+
+Treat this the way the Databricks skill treats notebook triage: it is the first risk-sorting step.
+
+### Detection checklist
+
+Look for these signals in each component:
+
+- uses `.path`
+- uses `.uri`
+- uses `InputPath(...)` / `OutputPath(...)`
+- writes sibling files next to the artifact path
+- passes the artifact path into an external binary / container / SDK
+- uses importer components
+- returns only scalars, small dicts, or normal Python objects
+
+### Classification outcomes
+
+| Classification | Signs | Migration stance |
+|---|---|---|
+| **Auto-translatable (value-centric)** | Uses artifacts as data values; `.path` is just a serialization boundary | Convert to normal Python inputs/returns and let ZenML materialize them |
+| **Semi-automatic (location-aware)** | Uses `.path` / `.uri` meaningfully, but the contract is still understandable | Keep an explicit reference type, `Path`, URI object, or custom materializer |
+| **Manual redesign required (template / platform / path coupled)** | Relies on placeholders, compiled template behavior, directory conventions, or opaque runtime injection | Stop and redesign before claiming a migration |
+
+### Examples
+
+| Pattern | Classification | Why |
+|---|---|---|
+| reads CSV from `dataset.path`, then returns a trained sklearn model | auto-translatable | The file path is only a serialization boundary |
+| passes `model.uri` into a downstream deployment helper | semi-automatic | The location identity matters |
+| writes multiple artifacts into a KFP-managed folder structure and expects downstream placeholder substitution | manual redesign required | The contract is tied to KFP runtime behavior |
+
+---
+
+## Behavioral Differences
+
+These are the differences that are often safe to migrate, but unsafe to hide.
+
+### Artifact model
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| primary unit | runtime-managed artifact reference | materialized Python value |
+| common access pattern | `.path`, `.uri`, metadata helpers | typed objects + materializers |
+| naming | artifact classes and pipeline metadata | `Annotated[..., "name"]`, artifact metadata, materializers |
+| large-file handling | explicit file/URI contract | artifact store + materializer contract |
+
+### Pipeline execution / compile model
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| authoring output | compiled template | Python pipeline definition |
+| submission model | `PipelineJob(template_path=...)` | pipeline execution through active stack |
+| template lifecycle | first-class | no direct equivalent |
+| portability story | tied to KFP / Vertex authoring | stack abstraction across backends |
+
+### Control flow
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| runtime branching | built into KFP DSL / backend | dynamic pipelines with `.load()` |
+| fan-out | `dsl.ParallelFor` | `.map()` |
+| fan-in | `dsl.Collected` | reducer step over mapped outputs |
+| exit handling | `dsl.ExitHandler` | no exact equivalent |
+
+### Resource management
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| portable resources | limited | `ResourceSettings(...)` |
+| backend-specific knobs | task / job settings | orchestrator-specific settings |
+| images / packages | component decorators | `DockerSettings(...)` and build config |
+| network / service account / persistent resources | Vertex job config | Vertex orchestrator configuration |
+
+### Scheduling
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| schedule creation | `PipelineJob.create_schedule(...)` | `Schedule(...)` |
+| supported knobs | richer lifecycle / concurrency surface | common subset only |
+| schedule management | Vertex APIs / UI | partial orchestration-layer support |
+| template dependency | often compiled-template based | not part of ZenML model |
+
+### Monitoring, experiments, and metadata
+
+| Aspect | Vertex / KFP | ZenML |
+|---|---|---|
+| experiments | Vertex Experiments | experiment tracker stack component |
+| model resources | Vertex Model Registry | ZenML model / artifact control-plane concepts |
+| metadata | Vertex ML Metadata | ZenML metadata store + artifact lineage |
+| run UI | Vertex Pipeline UI | ZenML dashboard plus orchestrator metadata links |
+
+---
+
+## Migration Decision Tree
+
+Use this to classify each node before rewriting it:
+
+```text
+1) Is this node a GCPC operator?
+   ├── Yes -> classify as absent -> rewrite as SDK-calling step
+   └── No -> continue
+
+2) Is it a container component?
+   ├── Yes -> classify as approximate -> inspect command/args/image contract carefully
+   └── No -> continue
+
+3) Is it a plain Python component?
+   ├── Yes -> continue
+   └── No -> analyze as a custom platform pattern
+
+4) What is the artifact contract?
+   ├── value-centric -> normal typed inputs/returns
+   ├── location-aware -> explicit URI/path contract or custom materializer
+   └── template/platform/path-coupled -> manual redesign required
+
+5) Does control flow depend on upstream outputs?
+   ├── Yes -> dynamic pipeline design required
+   └── No -> static pipeline may be fine
+
+6) Does the pipeline rely on dsl.If / dsl.Condition / dsl.ParallelFor / dsl.Collected?
+   ├── Yes -> record as approximate and document the semantic change
+   └── No -> continue
+
+7) Does the workflow rely on dsl.ExitHandler or final-status cleanup?
+   ├── Yes -> classify as absent -> redesign cleanup / notifications
+   └── No -> continue
+
+8) Does the user need template-based submission to remain?
+   ├── Yes -> partial migration via black-box PipelineJob submission step
+   └── No -> full ZenML-native rewrite
+```
+
+---
+
+## ZenML Features with No Vertex Equivalent
+
+These are useful "what you get for free" items to mention in migration reports.
+
+| Feature | Value |
+|---|---|
+| **stack abstraction** | same pipeline code can move across stacks without rewriting the workflow |
+| **portable resource settings** | resource intent is expressed separately from backend-specific details |
+| **materializers** | explicit, reusable serialization logic for domain-specific Python types |
+| **artifact versioning and lineage** | richer artifact tracking as a first-class concept |
+| **step caching** | rerun only what changed |
+| **model control plane** | explicit model lifecycle capabilities in the ZenML ecosystem |
+| **service connectors** | unified auth abstraction for cloud services |
+| **snapshots and stack-aware runs** | a different reproducibility story from compiled templates |


### PR DESCRIPTION
## Summary

- Adds **9 new migration skills** covering all major ML/data orchestrators: Argo Workflows, AzureML, Dagster, Flyte, Kedro, Metaflow, Prefect, SageMaker, and Vertex AI
- Each skill follows the established migration skill structure with `SKILL.md` workflow instructions plus three reference docs (`concept-map.md`, `code-patterns.md`, `gaps-and-flags.md`)
- Updates `marketplace.json` with all new plugin entries, `CLAUDE.md` with updated architecture table, `AGENTS.md`, and `README.md`
- Fixes minor drift in existing Airflow and Databricks concept-map tables

These join the existing Airflow and Databricks migration skills, bringing total migration coverage to **11 orchestrators**.

## New skills

| Skill | Migrates from |
|-------|--------------|
| `zenml-argo-migration` | Argo Workflows (Kubernetes-native DAGs) |
| `zenml-azureml-migration` | Azure ML SDK v2 pipelines |
| `zenml-dagster-migration` | Dagster assets, ops, jobs, graphs |
| `zenml-flyte-migration` | Flyte workflows, tasks, LaunchPlans |
| `zenml-kedro-migration` | Kedro pipelines & Data Catalog |
| `zenml-metaflow-migration` | Metaflow FlowSpec flows |
| `zenml-prefect-migration` | Prefect flows & tasks (v2) |
| `zenml-sagemaker-migration` | SageMaker Pipelines |
| `zenml-vertexai-migration` | Vertex AI Pipelines (KFP v2) |

## Test plan

- [ ] Install each plugin via `/plugin install <name>@zenml` and verify SKILL.md loads
- [ ] Spot-check concept maps for accuracy against current ZenML docs
- [ ] Verify marketplace.json is valid JSON and all plugin entries resolve
- [ ] Confirm existing Airflow and Databricks skills still work after concept-map fixes